### PR TITLE
Add vitest and colorUtils tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -80,6 +81,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/utils/__tests__/colorUtils.test.ts
+++ b/src/utils/__tests__/colorUtils.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { hexToHSL } from '../colorUtils';
+
+describe('hexToHSL', () => {
+  it('converts red hex to hsl', () => {
+    expect(hexToHSL('#ff0000')).toBe('0 100% 50%');
+  });
+
+  it('converts green hex to hsl', () => {
+    expect(hexToHSL('#00ff00')).toBe('120 100% 50%');
+  });
+
+  it('converts blue hex to hsl', () => {
+    expect(hexToHSL('#0000ff')).toBe('240 100% 50%');
+  });
+
+  it('converts gray hex to hsl', () => {
+    expect(hexToHSL('#808080')).toBe('0 0% 50%');
+  });
+
+  it('converts white hex to hsl', () => {
+    expect(hexToHSL('#ffffff')).toBe('0 0% 100%');
+  });
+});

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "types": ["vitest"]
+  },
+  "include": [
+    "vitest.config.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- install vitest and add a test script
- configure vitest
- create tsconfig for vitest
- add unit tests for `hexToHSL`

## Testing
- `npm test` *(fails: vitest not found)*