### PR TITLE
Fix voice WebSocket default

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ VITE_OPENAI_MODEL=gpt-4o
 ```
 
 `VITE_SUPABASE_PROJECT_REF` controls which Supabase project the realtime voice
-WebSocket connects to. `VITE_OPENAI_MODEL` sets the model used by the edge
-functions when contacting OpenAI.
+WebSocket connects to. If this variable is omitted, the app now falls back to a
+relative `/functions/v1/realtime-chat` path which works in preview deployments.
+`VITE_OPENAI_MODEL` sets the model used by the edge functions when contacting
+OpenAI.
 
 ## How can I deploy this project?
 

--- a/src/utils/voice/voiceConnection.ts
+++ b/src/utils/voice/voiceConnection.ts
@@ -17,18 +17,21 @@ export const createVoiceWebSocket = async (
     // Update state to show connecting status
     setSession(prev => ({ ...prev, isConnecting: true }));
 
-    // Use configurable project reference with a sensible fallback
+    // Use configurable project reference with a sensible fallback. When the
+    // default placeholder project ID is in use, fall back to a relative URL so
+    // previews can still access the edge function without DNS setup.
     const projectRef = SUPABASE_PROJECT_REF;
-    
-    if (!projectRef) {
-      throw new Error('Could not determine Supabase project reference');
+
+    let wsUrl: string;
+    if (projectRef && projectRef !== 'xrrauvcciuiaztzajmeq') {
+      wsUrl = `wss://${projectRef}.supabase.co/functions/v1/realtime-chat`;
+    } else {
+      const base = window.location.origin.replace(/^http/i, 'ws');
+      wsUrl = `${base}/functions/v1/realtime-chat`;
     }
 
-    // Get full WebSocket URL for the Edge Function
-    const wsUrl = `wss://${projectRef}.supabase.co/functions/v1/realtime-chat`;
-    
     console.log('Connecting to WebSocket:', wsUrl);
-    
+
     // Create WebSocket with explicit error handling
     const ws = new WebSocket(wsUrl);
 


### PR DESCRIPTION
## Summary
- fallback to a relative websocket URL when no SUPABASE project is configured
- document the new fallback behaviour in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*