### PR TITLE
Fix markdown list formatting

### DIFF
--- a/src/styles/components/messages.css
+++ b/src/styles/components/messages.css
@@ -7,7 +7,7 @@
 
 /* Bot message styling (no bubble) */
 .message-bot {
-  white-space: pre-wrap;
+  white-space: normal;
 }
 
 /* Bot message markdown styling */


### PR DESCRIPTION
## Summary
- keep bot chat whitespace normal so React Markdown doesn't insert unwanted line breaks

## Testing
- `npx vitest` *(fails: EHOSTUNREACH registry.npmjs.org)*