### PR TITLE
Secure voice relay with JWT

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -4,4 +4,4 @@ project_id = "xrrauvcciuiaztzajmeq"
 
 [functions]
 [functions.realtime-chat]
-verify_jwt = false
+verify_jwt = true


### PR DESCRIPTION
## Summary
- enforce JWT verification in realtime voice relay
- remove `verify_jwt = false` setting so Supabase checks JWT

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*