### PR TITLE
Add system_message to profiles

### DIFF
--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -65,9 +65,14 @@ const SignUpForm: React.FC = () => {
       
       // Also save the user type as 'adult' in their profile
       if (data?.user) {
-        await supabase.from('profiles').update({
-          user_role: 'adult'
-        }).eq('id', data.user.id);
+        await supabase
+          .from('profiles')
+          .update({
+            user_role: 'adult',
+            system_message:
+              'You are a helpful assistant. Provide friendly, concise responses.'
+          })
+          .eq('id', data.user.id);
       }
       
       toast({

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -137,7 +137,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
       // Check if user has adult role
       const { data: profileData, error: profileError } = await supabase
         .from('profiles')
-        .select('user_role')
+        .select('user_role, system_message')
         .eq('id', user.id)
         .single();
 

--- a/src/hooks/useUserPermissions.ts
+++ b/src/hooks/useUserPermissions.ts
@@ -38,7 +38,7 @@ export const useUserPermissions = (): {
       try {
         const { data: profileData, error: profileError } = await supabase
           .from('profiles')
-          .select('user_role, subscription_tier')
+          .select('user_role, subscription_tier, system_message')
           .eq('id', user.id)
           .single();
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -76,6 +76,7 @@ export type Database = {
           display_name: string | null
           id: string
           parent_id: string | null
+          system_message: string | null
           subscription_tier: string
           updated_at: string
           user_role: string
@@ -87,6 +88,7 @@ export type Database = {
           display_name?: string | null
           id: string
           parent_id?: string | null
+          system_message?: string | null
           subscription_tier?: string
           updated_at?: string
           user_role?: string
@@ -98,6 +100,7 @@ export type Database = {
           display_name?: string | null
           id?: string
           parent_id?: string | null
+          system_message?: string | null
           subscription_tier?: string
           updated_at?: string
           user_role?: string

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -19,6 +19,9 @@ const Profile: React.FC = () => {
   
   const [name, setName] = useState(user?.user_metadata?.name || 'User');
   const [email, setEmail] = useState(user?.email || '');
+  const [systemMessage, setSystemMessage] = useState(
+    'You are a helpful assistant. Provide friendly, concise responses.'
+  );
   const [loading, setLoading] = useState(false);
   
   // Fetch profile on load
@@ -29,7 +32,7 @@ const Profile: React.FC = () => {
       try {
         const { data, error } = await supabase
           .from('profiles')
-          .select('display_name, user_role, subscription_tier')
+          .select('display_name, user_role, subscription_tier, system_message')
           .eq('id', user.id)
           .single();
         
@@ -37,6 +40,10 @@ const Profile: React.FC = () => {
         
         if (data) {
           setName(data.display_name || name);
+          setSystemMessage(
+            data.system_message ||
+              'You are a helpful assistant. Provide friendly, concise responses.'
+          );
         }
       } catch (error) {
         console.error('Error fetching profile:', error);
@@ -76,6 +83,7 @@ const Profile: React.FC = () => {
         .from('profiles')
         .update({
           display_name: name,
+          system_message: systemMessage,
           updated_at: new Date().toISOString()
         })
         .eq('id', user.id);

--- a/supabase/migrations/20250517141000_add_system_message_to_profiles.sql
+++ b/supabase/migrations/20250517141000_add_system_message_to_profiles.sql
@@ -1,0 +1,1 @@
+ALTER TABLE profiles ADD COLUMN system_message text;


### PR DESCRIPTION
## Summary
- add `system_message` column via migration
- regenerate supabase types for the new column
- update sign up and profile screens to handle `system_message`
- query `system_message` when checking permissions

## Testing
- `npx vitest` *(fails: request to https://registry.npmjs.org/vitest failed, reason: connect EHOSTUNREACH)*