### PR TITLE
Add system message handling in chat

### DIFF
--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -16,6 +16,32 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const { heroColor, setHeroColor } = useHeroColor();
   const { user } = useAuth();
   const [isInitialized, setIsInitialized] = useState(false);
+  const [systemMessage, setSystemMessage] = useState(
+    'You are a helpful assistant. Provide friendly, concise responses.'
+  );
+
+  useEffect(() => {
+    const fetchSystemMessage = async () => {
+      if (!user) return;
+
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('system_message')
+        .eq('id', user.id)
+        .single();
+
+      if (error) {
+        console.error('Error fetching system message:', error);
+        return;
+      }
+
+      if (data && data.system_message) {
+        setSystemMessage(data.system_message);
+      }
+    };
+
+    fetchSystemMessage();
+  }, [user]);
   
   const { 
     chatSessions, 
@@ -32,12 +58,12 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const initialMessages = activeSession?.messages || [];
   
   // Message handler for the active chat
-  const { 
-    messages, 
-    setMessages, 
-    isWaitingForResponse, 
-    addMessage: handleMessage 
-  } = useMessageHandler(initialMessages);
+  const {
+    messages,
+    setMessages,
+    isWaitingForResponse,
+    addMessage: handleMessage
+  } = useMessageHandler(initialMessages, systemMessage);
 
   // Set messages when active session changes or loads
   useEffect(() => {
@@ -192,9 +218,10 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
       messages, 
       addMessage,
       deleteMessage,
-      heroColor, 
-      setHeroColor, 
+      heroColor,
+      setHeroColor,
       isWaitingForResponse,
+      systemMessage,
       chatName: activeSession.name,
       chatSessions,
       activeChatId,

--- a/src/hooks/useMessageHandler.ts
+++ b/src/hooks/useMessageHandler.ts
@@ -4,7 +4,10 @@ import { Message } from '@/types/chat';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from '@/components/ui/use-toast';
 
-export const useMessageHandler = (initialMessages: Message[] = []) => {
+export const useMessageHandler = (
+  initialMessages: Message[] = [],
+  systemMessage: string = 'You are a helpful assistant. Provide friendly, concise responses.'
+) => {
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
 
@@ -32,9 +35,9 @@ export const useMessageHandler = (initialMessages: Message[] = []) => {
         openaiMessages.push({ role: 'user' as const, content });
         
         // Add system message at the beginning
-        openaiMessages.unshift({ 
+        openaiMessages.unshift({
           role: 'user' as const, // Changed from 'system' to 'user' as a workaround
-          content: 'You are a helpful assistant. Provide friendly, concise responses.'
+          content: systemMessage
         });
         
         // Call the Supabase edge function

--- a/src/types/chatContext.ts
+++ b/src/types/chatContext.ts
@@ -15,6 +15,7 @@ export interface ChatContextType {
   heroColor: string;
   setHeroColor: (color: string) => void;
   isWaitingForResponse: boolean;
+  systemMessage: string;
   chatName: string | null;
   chatSessions: ChatSession[];
   activeChatId: string;


### PR DESCRIPTION
## Summary
- load system message from `profiles` on chat provider mount
- store system message in context state
- pass system message into message handler
- read system message when preparing OpenAI calls

## Testing
- `npm install` *(fails: Cannot find package '@eslint/js')*
- `bun install` *(fails: connection refused while resolving packages)*