### PR TITLE
Add child chat history view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { ChatProvider } from "./contexts/ChatContext";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import Profile from "./pages/Profile";
+import ChildChatHistory from "./pages/ChildChatHistory";
 import Login from "./pages/Login";
 import AuthGuard from "./components/auth/AuthGuard";
 
@@ -30,13 +31,21 @@ const App = () => (
                   </AuthGuard>
                 } 
               />
-              <Route 
-                path="/profile" 
+              <Route
+                path="/profile"
                 element={
                   <AuthGuard>
                     <Profile />
                   </AuthGuard>
-                } 
+                }
+              />
+              <Route
+                path="/child-history/:childId"
+                element={
+                  <AuthGuard>
+                    <ChildChatHistory />
+                  </AuthGuard>
+                }
               />
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/components/profile/ChildAccountsSection.tsx
+++ b/src/components/profile/ChildAccountsSection.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/contexts/AuthContext';
+import { useFeatureAccess } from '@/hooks/useFeatureAccess';
+import { supabase } from '@/integrations/supabase/client';
+import { useNavigate } from 'react-router-dom';
+
+interface ChildAccount {
+  id: string;
+  display_name: string | null;
+}
+
+const ChildAccountsSection: React.FC = () => {
+  const { user } = useAuth();
+  const { isAdult } = useFeatureAccess();
+  const [children, setChildren] = useState<ChildAccount[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchChildren = async () => {
+      if (!user || !isAdult) return;
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('id, display_name')
+        .eq('parent_id', user.id);
+      if (error) {
+        console.error('Error fetching child accounts:', error);
+        return;
+      }
+      setChildren(data || []);
+    };
+    fetchChildren();
+  }, [user, isAdult]);
+
+  if (!isAdult) return null;
+
+  return (
+    <div className="space-y-3">
+      <Label>Child Accounts</Label>
+      {children.length === 0 ? (
+        <p className="text-sm text-gray-500">No child accounts found.</p>
+      ) : (
+        <div className="space-y-2">
+          {children.map((child) => (
+            <Button
+              key={child.id}
+              variant="outline"
+              className="w-full justify-start"
+              onClick={() => navigate(`/child-history/${child.id}`)}
+            >
+              {child.display_name || 'Unnamed Child'}
+            </Button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ChildAccountsSection;

--- a/src/hooks/chatSessions/useChatDatabase.ts
+++ b/src/hooks/chatSessions/useChatDatabase.ts
@@ -5,14 +5,24 @@ import { ChatSession } from '@/types/chatContext';
 import { supabase } from '@/integrations/supabase/client';
 
 export const useChatDatabase = () => {
-  // Fetch all sessions for a user
-  const fetchUserSessions = useCallback(async (userId: string) => {
+  // Fetch all sessions for a user. If no ID is provided, fall back to the
+  // currently authenticated user.
+  const fetchUserSessions = useCallback(async (userId?: string) => {
     try {
-      // Fetch all chat sessions for the current user
+      let targetId = userId;
+
+      if (!targetId) {
+        const { data: userData, error: userError } = await supabase.auth.getUser();
+        if (userError) throw userError;
+        targetId = userData?.user?.id;
+      }
+
+      if (!targetId) return [];
+
       const { data, error } = await supabase
         .from('chat_sessions')
         .select('id, name, last_updated')
-        .eq('user_id', userId)
+        .eq('user_id', targetId)
         .order('last_updated', { ascending: false });
       
       if (error) throw error;

--- a/src/pages/ChildChatHistory.tsx
+++ b/src/pages/ChildChatHistory.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useChatDatabase } from '@/hooks/chatSessions/useChatDatabase';
+import { ChatSession } from '@/types/chatContext';
+import MessageList from '@/components/chat/MessageList';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+
+const ChildChatHistory: React.FC = () => {
+  const { childId } = useParams<{ childId: string }>();
+  const navigate = useNavigate();
+  const { fetchUserSessions } = useChatDatabase();
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!childId) return;
+      try {
+        const data = await fetchUserSessions(childId);
+        setSessions(data);
+        if (data.length > 0) {
+          setActiveId(data[0].id);
+        }
+      } catch (err) {
+        console.error('Error fetching child sessions:', err);
+      }
+    };
+    load();
+  }, [childId, fetchUserSessions]);
+
+  const activeSession = sessions.find(s => s.id === activeId);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="fixed top-0 w-full bg-white border-b border-gray-100 h-14 flex items-center px-4 z-10">
+        <Button variant="ghost" size="icon" onClick={() => navigate('/profile')}>
+          <ArrowLeft />
+          <span className="sr-only">Back</span>
+        </Button>
+        <h1 className="flex-1 text-center font-medium">Child Chat History</h1>
+      </header>
+      <main className="pt-20 px-4 max-w-md mx-auto space-y-4">
+        <div>
+          <h2 className="font-medium mb-2">Sessions</h2>
+          <ul className="space-y-2">
+            {sessions.map(session => (
+              <li key={session.id}>
+                <button
+                  className={`w-full text-left p-2 rounded border ${session.id === activeId ? 'bg-gray-100' : 'bg-white'}`}
+                  onClick={() => setActiveId(session.id)}
+                >
+                  {session.name || 'Untitled'}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+        {activeSession && (
+          <div className="border rounded p-2">
+            <h3 className="font-medium mb-2">Messages</h3>
+            <MessageList messages={activeSession.messages} />
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default ChildChatHistory;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -12,6 +12,7 @@ import UserInfoSection from '@/components/profile/UserInfoSection';
 import AccountTypeSection from '@/components/profile/AccountTypeSection';
 import SubscriptionSection from '@/components/profile/SubscriptionSection';
 import LogoutButton from '@/components/profile/LogoutButton';
+import ChildAccountsSection from '@/components/profile/ChildAccountsSection';
 
 const Profile: React.FC = () => {
   const { heroColor } = useChat();
@@ -125,7 +126,9 @@ const Profile: React.FC = () => {
         
         <div className="space-y-6">
           <AccountTypeSection />
-          
+
+          <ChildAccountsSection />
+
           <SubscriptionSection />
           
           <LogoutButton />


### PR DESCRIPTION
## Summary
- allow `fetchUserSessions` to optionally accept a user ID and default to the current user
- add component to list a parent's child accounts
- add page to view a child's chat history
- link child history from the profile page
- register the new route in `App`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*