### PR TITLE
Add child chat history view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import Profile from "./pages/Profile";
 import Login from "./pages/Login";
+import ChildHistory from "./pages/ChildHistory";
 import AuthGuard from "./components/auth/AuthGuard";
 
 const queryClient = new QueryClient();
@@ -30,13 +31,21 @@ const App = () => (
                   </AuthGuard>
                 } 
               />
-              <Route 
-                path="/profile" 
+              <Route
+                path="/profile"
                 element={
                   <AuthGuard>
                     <Profile />
                   </AuthGuard>
-                } 
+                }
+              />
+              <Route
+                path="/child-history/:childId"
+                element={
+                  <AuthGuard>
+                    <ChildHistory />
+                  </AuthGuard>
+                }
               />
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/components/profile/ChildAccountsSection.tsx
+++ b/src/components/profile/ChildAccountsSection.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { toast } from '@/components/ui/use-toast';
 import EditableField from './EditableField';
+import { Link } from 'react-router-dom';
 
 interface ChildProfile {
   id: string;
@@ -124,6 +125,12 @@ const ChildAccountsSection: React.FC = () => {
               inputClassName="max-w-[250px] border-gray-300"
               buttonClassName="h-7 w-7 text-gray-500 hover:text-gray-700"
             />
+            <Link
+              to={`/child-history/${child.id}`}
+              className="text-xs text-blue-600 hover:underline"
+            >
+              View history
+            </Link>
           </div>
         ))}
       </div>

--- a/src/components/profile/ChildChatHistory.tsx
+++ b/src/components/profile/ChildChatHistory.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import { ChatSession } from '@/types/chatContext';
+import { useChatDatabase } from '@/hooks/chatSessions/useChatDatabase';
+import MessageList from '@/components/chat/MessageList';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent
+} from '@/components/ui/accordion';
+
+interface ChildChatHistoryProps {
+  childId: string;
+}
+
+const ChildChatHistory: React.FC<ChildChatHistoryProps> = ({ childId }) => {
+  const { fetchUserSessions } = useChatDatabase();
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchUserSessions(childId);
+        setSessions(data);
+      } catch (err) {
+        console.error('Failed to load child sessions', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [childId, fetchUserSessions]);
+
+  if (loading) {
+    return <p className="p-4">Loading...</p>;
+  }
+
+  if (sessions.length === 0) {
+    return <p className="p-4">No chat history.</p>;
+  }
+
+  return (
+    <Accordion type="single" collapsible className="w-full">
+      {sessions.map((session) => (
+        <AccordionItem key={session.id} value={session.id}>
+          <AccordionTrigger>
+            {session.name || 'Unnamed chat'}
+          </AccordionTrigger>
+          <AccordionContent>
+            <MessageList messages={session.messages} />
+          </AccordionContent>
+        </AccordionItem>
+      ))}
+    </Accordion>
+  );
+};
+
+export default ChildChatHistory;

--- a/src/hooks/chatSessions/useChatDatabase.ts
+++ b/src/hooks/chatSessions/useChatDatabase.ts
@@ -5,8 +5,19 @@ import { ChatSession } from '@/types/chatContext';
 import { supabase } from '@/integrations/supabase/client';
 
 export const useChatDatabase = () => {
-  // Fetch all sessions for a user
-  const fetchUserSessions = useCallback(async (userId: string) => {
+  // Fetch all sessions for a user. If no userId is provided, use the
+  // currently authenticated user.
+  const fetchUserSessions = useCallback(async (userId?: string) => {
+    if (!userId) {
+      const {
+        data: { user },
+        error,
+      } = await supabase.auth.getUser();
+      if (error || !user) {
+        throw error || new Error('Unable to determine user');
+      }
+      userId = user.id;
+    }
     try {
       // Fetch all chat sessions for the current user
       const { data, error } = await supabase

--- a/src/pages/ChildHistory.tsx
+++ b/src/pages/ChildHistory.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import ChildChatHistory from '@/components/profile/ChildChatHistory';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+
+const ChildHistory: React.FC = () => {
+  const { childId } = useParams<{ childId: string }>();
+  const navigate = useNavigate();
+
+  if (!childId) {
+    return <p className="p-4">Child not found.</p>;
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="fixed top-0 w-full bg-white border-b border-gray-100 h-14 flex items-center px-4 z-10">
+        <Button variant="ghost" size="icon" onClick={() => navigate('/profile')}>
+          <ArrowLeft />
+          <span className="sr-only">Back</span>
+        </Button>
+        <h1 className="flex-1 text-center font-medium">Chat History</h1>
+      </header>
+      <main className="pt-16 p-4 max-w-md mx-auto">
+        <ChildChatHistory childId={childId} />
+      </main>
+    </div>
+  );
+};
+
+export default ChildHistory;


### PR DESCRIPTION
## Summary
- allow `fetchUserSessions` to accept optional userId (defaults to current auth user)
- build `ChildChatHistory` component listing a child's chat sessions
- add `/child-history/:childId` page using the new component
- link to the history view from each child account entry

## Testing
- `npx vitest` *(fails: request to https://registry.npmjs.org/vitest failed, reason: connect EHOSTUNREACH)*