### PR TITLE
Add child account creation function

### DIFF
--- a/src/components/profile/ChildAccountsSection.tsx
+++ b/src/components/profile/ChildAccountsSection.tsx
@@ -8,6 +8,7 @@ import { Label } from '@/components/ui/label';
 import { toast } from '@/components/ui/use-toast';
 import EditableField from './EditableField';
 import { Link } from 'react-router-dom';
+import { createChildAccount } from '@/utils/createChildAccount';
 
 interface ChildProfile {
   id: string;
@@ -56,15 +57,7 @@ const ChildAccountsSection: React.FC = () => {
 
     try {
       setLoading(true);
-      const { data, error } = await supabase.functions.invoke(
-        'create-child-account',
-        {
-          body: { email, password, system_message: newMessage }
-        }
-      );
-      if (error || (data && data.error)) {
-        throw new Error(error?.message || data?.error);
-      }
+      await createChildAccount(email, password);
       toast({ title: 'Child account created' });
       setEmail('');
       setPassword('');

--- a/src/utils/createChildAccount.ts
+++ b/src/utils/createChildAccount.ts
@@ -1,0 +1,17 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export const createChildAccount = async (email: string, password: string) => {
+  const { data, error } = await supabase.functions.invoke('create-child-account', {
+    body: { email, password }
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (data && data.error) {
+    throw new Error(data.error);
+  }
+
+  return data;
+};

--- a/supabase/functions/create-child-account/index.ts
+++ b/supabase/functions/create-child-account/index.ts
@@ -2,6 +2,9 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
+const DEFAULT_CHILD_SYSTEM_MESSAGE =
+  "You are a friendly assistant for children. Keep responses safe and age-appropriate.";
+
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -61,7 +64,7 @@ serve(async (req) => {
       });
     }
 
-    const { email, password, system_message } = await req.json();
+    const { email, password } = await req.json();
 
     if (!email || !password) {
       return new Response(JSON.stringify({ error: 'Email and password required' }), {
@@ -87,7 +90,7 @@ serve(async (req) => {
       id: childUserId,
       parent_id: userId,
       user_role: 'child',
-      system_message: system_message ?? null,
+      system_message: DEFAULT_CHILD_SYSTEM_MESSAGE,
     });
 
     if (insertError) {


### PR DESCRIPTION
## Summary
- add a helper to invoke the `create-child-account` Supabase function
- use the helper in the child account UI
- set a default system message when creating child accounts

## Testing
- `npm test` *(fails: vitest not found)*