### PR TITLE
Add documentation for child account function

### DIFF
--- a/supabase/functions/create-child-account/README.md
+++ b/supabase/functions/create-child-account/README.md
@@ -1,0 +1,34 @@
+# create-child-account Edge Function
+
+This Supabase Edge Function allows an authenticated adult user to create a child account.
+
+## Environment variables
+- `SUPABASE_URL` – Supabase project URL
+- `SUPABASE_ANON_KEY` – anonymous API key used for verifying JWT tokens
+- `SUPABASE_SERVICE_ROLE_KEY` – service role key required to create new users
+
+## HTTP request
+`POST /functions/v1/create-child-account`
+
+### Headers
+- `Authorization: Bearer <parent_access_token>`
+- `Content-Type: application/json`
+
+### Body
+```json
+{
+  "email": "child@example.com",
+  "password": "strongpassword"
+}
+```
+
+### Response
+```json
+{
+  "success": true,
+  "user_id": "<new-child-user-id>"
+}
+```
+
+If the caller is not authenticated as an adult user, the function returns an error message with the appropriate status code.
+

--- a/supabase/functions/create-child-account/index.ts
+++ b/supabase/functions/create-child-account/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Creates a child account linked to the authenticated adult user.
+ * Request body should include `email` and `password`.
+ */
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";


### PR DESCRIPTION
## Summary
- document the `create-child-account` edge function with new README
- add introductory comments at top of function implementation

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find '@eslint/js')*