### PR TITLE
Fix missing profile rows on signup

### DIFF
--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -63,16 +63,16 @@ const SignUpForm: React.FC = () => {
       
       if (error) throw error;
       
-      // Also save the user type as 'adult' in their profile
+      // Ensure a matching profile exists for the new user
       if (data?.user) {
         await supabase
           .from('profiles')
-          .update({
+          .upsert({
+            id: data.user.id,
             user_role: 'adult',
             system_message:
               'You are a helpful assistant. Provide friendly, concise responses.'
-          })
-          .eq('id', data.user.id);
+          });
       }
       
       toast({


### PR DESCRIPTION
## Summary
- ensure a profile row is created during sign up

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/chat-frontier-family/node_modules/@eslint/js/index.js')*
- `npm ci` *(fails: EHOSTUNREACH while fetching packages)*