### PR TITLE
Fix privacy leakage with RLS and client filtering

### DIFF
--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -75,6 +75,13 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }, [activeSession, setMessages, isInitialized]);
 
+  // Reset messages when user signs out
+  useEffect(() => {
+    if (!user) {
+      setMessages([]);
+    }
+  }, [user, setMessages]);
+
   // Set up chat name generation
   useChatNameGenerator(
     messages, 

--- a/src/hooks/chatSessions/useChatDatabase.ts
+++ b/src/hooks/chatSessions/useChatDatabase.ts
@@ -32,9 +32,9 @@ export const useChatDatabase = () => {
         // Format data for our state
         const sessions = await Promise.all(data.map(async (session) => {
           // Fetch messages for this session
-          const { data: messagesData, error: messagesError } = await supabase
+        const { data: messagesData, error: messagesError } = await supabase
             .from('chat_messages')
-            .select('*')
+            .select('id, content, is_user, created_at, session_id')
             .eq('session_id', session.id)
             .order('created_at', { ascending: true });
           

--- a/src/hooks/chatSessions/useChatSessions.ts
+++ b/src/hooks/chatSessions/useChatSessions.ts
@@ -76,6 +76,14 @@ export const useChatSessions = (initialMessages: Message[] = []) => {
     loadSessions();
   }, [user, fetchUserSessions, createNewChatInDb, setActiveChatId]);
 
+  // Clear sessions when user signs out
+  useEffect(() => {
+    if (!user) {
+      setChatSessions([]);
+      setActiveChatId('');
+    }
+  }, [user, setActiveChatId]);
+
   return { 
     chatSessions, 
     activeChatId, 

--- a/supabase/migrations/20250517152000_add_rls_on_chat.sql
+++ b/supabase/migrations/20250517152000_add_rls_on_chat.sql
@@ -1,0 +1,34 @@
+ALTER TABLE public.chat_sessions ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can read their own sessions"
+  ON public.chat_sessions FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "Users can insert their own sessions"
+  ON public.chat_sessions FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE public.chat_messages ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can read their own messages"
+  ON public.chat_messages FOR SELECT TO authenticated
+  USING (
+    session_id IN (
+      SELECT id FROM public.chat_sessions WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can insert their own messages"
+  ON public.chat_messages FOR INSERT TO authenticated
+  WITH CHECK (
+    session_id IN (
+      SELECT id FROM public.chat_sessions WHERE user_id = auth.uid()
+    )
+  );
+
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can read their own profile"
+  ON public.profiles FOR SELECT TO authenticated
+  USING (id = auth.uid());
+
+CREATE POLICY "Users can insert their own profile"
+  ON public.profiles FOR INSERT TO authenticated
+  WITH CHECK (id = auth.uid());


### PR DESCRIPTION
## Summary
- enforce row level security on chat tables and profiles
- defensively filter chat messages in `useChatDatabase`
- clear chat sessions and messages when the user signs out

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*