### PR TITLE
Ensure adult role for new users

### DIFF
--- a/supabase/migrations/20250517153000_set_adult_user_role.sql
+++ b/supabase/migrations/20250517153000_set_adult_user_role.sql
@@ -1,0 +1,5 @@
+-- Ensure new users default to adult role
+ALTER TABLE profiles ALTER COLUMN user_role SET DEFAULT 'adult';
+
+-- Update any existing parent roles to adult
+UPDATE profiles SET user_role='adult' WHERE user_role='parent';


### PR DESCRIPTION
## Summary
- ensure any users with `parent` user_role are moved to `adult`
- set default user_role to `adult` in new migrations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*