### PR TITLE
Use default adult or child messages

### DIFF
--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -69,9 +69,7 @@ const SignUpForm: React.FC = () => {
           .from('profiles')
           .upsert({
             id: data.user.id,
-            user_role: 'adult',
-            system_message:
-              'You are a helpful assistant. Provide friendly, concise responses.'
+            user_role: 'adult'
           });
       }
       

--- a/src/config/systemMessages.ts
+++ b/src/config/systemMessages.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_ADULT_SYSTEM_MESSAGE = 'You are a helpful assistant. Provide friendly, concise responses.';
+export const DEFAULT_CHILD_SYSTEM_MESSAGE = 'You are a friendly assistant for children. Keep responses safe and age-appropriate.';
+
+export const getDefaultSystemMessage = (role: 'adult' | 'child' = 'adult'): string => {
+  return role === 'child' ? DEFAULT_CHILD_SYSTEM_MESSAGE : DEFAULT_ADULT_SYSTEM_MESSAGE;
+};

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -9,6 +9,10 @@ import { useChatNameGenerator } from '@/hooks/useChatNameGenerator';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/components/ui/use-toast';
 import { supabase } from '@/integrations/supabase/client';
+import {
+  DEFAULT_ADULT_SYSTEM_MESSAGE,
+  getDefaultSystemMessage
+} from '@/config/systemMessages';
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
 
@@ -17,7 +21,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const { user } = useAuth();
   const [isInitialized, setIsInitialized] = useState(false);
   const [systemMessage, setSystemMessage] = useState(
-    'You are a helpful assistant. Provide friendly, concise responses.'
+    DEFAULT_ADULT_SYSTEM_MESSAGE
   );
 
   useEffect(() => {
@@ -26,7 +30,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       const { data, error } = await supabase
         .from('profiles')
-        .select('system_message')
+        .select('system_message, user_role')
         .eq('id', user.id)
         .single();
 
@@ -35,8 +39,16 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
         return;
       }
 
-      if (data && data.system_message) {
-        setSystemMessage(data.system_message);
+      if (data) {
+        if (data.system_message) {
+          setSystemMessage(data.system_message);
+        } else {
+          setSystemMessage(
+            getDefaultSystemMessage(
+              (data.user_role === 'child' ? 'child' : 'adult') as 'child' | 'adult'
+            )
+          );
+        }
       }
     };
 

--- a/src/hooks/useMessageHandler.ts
+++ b/src/hooks/useMessageHandler.ts
@@ -1,15 +1,21 @@
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Message } from '@/types/chat';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from '@/components/ui/use-toast';
+import { DEFAULT_ADULT_SYSTEM_MESSAGE } from '@/config/systemMessages';
 
 export const useMessageHandler = (
   initialMessages: Message[] = [],
-  systemMessage: string = 'You are a helpful assistant. Provide friendly, concise responses.'
+  systemMessage: string = DEFAULT_ADULT_SYSTEM_MESSAGE
 ) => {
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
+  const systemMessageRef = useRef(systemMessage);
+
+  useEffect(() => {
+    systemMessageRef.current = systemMessage;
+  }, [systemMessage]);
 
   const addMessage = async (content: string, isUser: boolean) => {
     const newMessage: Message = {
@@ -37,7 +43,7 @@ export const useMessageHandler = (
         // Add system message at the beginning
         openaiMessages.unshift({
           role: 'user' as const, // Changed from 'system' to 'user' as a workaround
-          content: systemMessage
+          content: systemMessageRef.current
         });
         
         // Call the Supabase edge function

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -5,6 +5,7 @@ import { useChat } from '@/contexts/ChatContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/components/ui/use-toast';
 import { supabase } from '@/integrations/supabase/client';
+import { DEFAULT_ADULT_SYSTEM_MESSAGE, getDefaultSystemMessage } from '@/config/systemMessages';
 
 // Import refactored components
 import ProfileHeader from '@/components/profile/ProfileHeader';
@@ -21,7 +22,7 @@ const Profile: React.FC = () => {
   const [name, setName] = useState(user?.user_metadata?.name || 'User');
   const [email, setEmail] = useState(user?.email || '');
   const [systemMessage, setSystemMessage] = useState(
-    'You are a helpful assistant. Provide friendly, concise responses.'
+    DEFAULT_ADULT_SYSTEM_MESSAGE
   );
   const [loading, setLoading] = useState(false);
   
@@ -43,7 +44,9 @@ const Profile: React.FC = () => {
           setName(data.display_name || name);
           setSystemMessage(
             data.system_message ||
-              'You are a helpful assistant. Provide friendly, concise responses.'
+              getDefaultSystemMessage(
+                (data.user_role === 'child' ? 'child' : 'adult') as 'child' | 'adult'
+              )
           );
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- keep default system messages in a dedicated config file
- apply role-based system message fallback in ChatContext
- use the new defaults when signing up and editing the profile
- keep system message value up to date in useMessageHandler
- avoid storing the default message on signup so future updates propagate

## Testing
- `npx vitest` *(fails: connect EHOSTUNREACH)*