### PR TITLE
Hide subscription tier behind feature flag

### DIFF
--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -16,6 +16,9 @@ export const featureFlags = {
   
   // User management
   userProfiles: true,
+
+  // Subscription features
+  subscriptionTier: false,
   
   // Future features
   imageGeneration: false,

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -14,10 +14,12 @@ import AccountTypeSection from '@/components/profile/AccountTypeSection';
 import SubscriptionSection from '@/components/profile/SubscriptionSection';
 import LogoutButton from '@/components/profile/LogoutButton';
 import ChildAccountsSection from '@/components/profile/ChildAccountsSection';
+import { useFeatureFlags } from '@/hooks/useFeatureFlags';
 
 const Profile: React.FC = () => {
   const { heroColor } = useChat();
   const { user } = useAuth();
+  const { isEnabled } = useFeatureFlags();
   
   const [name, setName] = useState(user?.user_metadata?.name || 'User');
   const [email, setEmail] = useState(user?.email || '');
@@ -132,7 +134,9 @@ const Profile: React.FC = () => {
 
           <ChildAccountsSection />
 
-          <SubscriptionSection />
+          {isEnabled('subscriptionTier') && (
+            <SubscriptionSection />
+          )}
 
           <LogoutButton />
         </div>


### PR DESCRIPTION
## Summary
- add `subscriptionTier` feature flag (disabled)
- render SubscriptionSection only when flag is enabled

## Testing
- `npx vitest` *(fails: request to https://registry.npmjs.org/vitest failed, reason: connect EHOSTUNREACH)*