### PR TITLE
Fix chat title generator loop

### DIFF
--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -96,10 +96,11 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   // Set up chat name generation
   useChatNameGenerator(
-    messages, 
-    activeSession.name, 
-    activeChatId, 
-    updateChatName
+    messages,
+    activeSession.name,
+    activeChatId,
+    updateChatName,
+    isWaitingForResponse
   );
 
   // Store the updated message list in the chat sessions

--- a/src/hooks/chatSessions/useSessionManagement.ts
+++ b/src/hooks/chatSessions/useSessionManagement.ts
@@ -49,7 +49,7 @@ export const useSessionManagement = (
         id: newId,
         name: null,
         messages: [{
-          content: "Hello! I'm powered by GPT-4o. How can I help you today?",
+          content: "Hello! How can I help you today?",
           isUser: false,
           timestamp: Date.now()
         }],


### PR DESCRIPTION
## Summary
- ensure chat title generation only runs once per session
- pass streaming state into name generator
- match default greeting across codebase

## Testing
- `npm test` *(fails: vitest not found)*