### PR TITLE
Fix parsing of OpenAI error responses

### DIFF
--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -45,8 +45,14 @@ serve(async (req) => {
     });
 
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.error?.message || 'Error connecting to OpenAI');
+      const contentType = response.headers.get('content-type') || '';
+      if (contentType.includes('application/json')) {
+        const errorData = await response.json();
+        throw new Error(errorData.error?.message || 'Error connecting to OpenAI');
+      } else {
+        const errorText = await response.text();
+        throw new Error(errorText || 'Error connecting to OpenAI');
+      }
     }
 
     if (streamRequested) {


### PR DESCRIPTION
## Summary
- handle cases where the OpenAI responses endpoint does not return JSON

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*