### PR TITLE
Fix chat API path

### DIFF
--- a/src/hooks/useMessageHandler.ts
+++ b/src/hooks/useMessageHandler.ts
@@ -117,7 +117,7 @@ export const useMessageHandler = (
               }
               try {
                 const json = JSON.parse(dataStr);
-                const token = json.responses?.[0]?.delta?.content || '';
+                const token = json.choices?.[0]?.delta?.content || '';
                 if (token) {
                   currentContent += token;
                   setMessages(prev => {

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -29,7 +29,7 @@ serve(async (req) => {
       throw new Error('Invalid or missing messages array');
     }
 
-    const response = await fetch('https://api.openai.com/v1/chat/responses', {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -65,7 +65,7 @@ serve(async (req) => {
       });
     } else {
       const data = await response.json();
-      const content = data.responses[0].message.content;
+      const content = data.choices[0].message.content;
 
       return new Response(
         JSON.stringify({ content }),


### PR DESCRIPTION
## Summary
- point chat function at correct OpenAI endpoint
- parse `choices` field returned by OpenAI

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*