### PR TITLE
Fix responses api usage

### DIFF
--- a/src/hooks/useMessageHandler.ts
+++ b/src/hooks/useMessageHandler.ts
@@ -71,7 +71,7 @@ export const useMessageHandler = (
               apikey: anon,
               ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {})
             },
-            body: JSON.stringify({ messages: openaiMessages }),
+            body: JSON.stringify({ input: { messages: openaiMessages } }),
             signal: controller.signal
           }
         );

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -23,9 +23,16 @@ serve(async (req) => {
     const url = new URL(req.url);
     const streamRequested = url.searchParams.get('stream') === 'true';
 
-    const { messages, model = Deno.env.get('OPENAI_MODEL') || 'gpt-4o', titleGeneration = false } = await req.json();
-    
-    if (!messages || !Array.isArray(messages)) {
+    const {
+      input,
+      messages,
+      model = Deno.env.get('OPENAI_MODEL') || 'gpt-4o',
+      titleGeneration = false,
+    } = await req.json();
+
+    const finalInput = input || { messages };
+
+    if (!finalInput?.messages || !Array.isArray(finalInput.messages)) {
       throw new Error('Invalid or missing messages array');
     }
 
@@ -37,7 +44,7 @@ serve(async (req) => {
       },
       body: JSON.stringify({
         model: model,
-        messages,
+        input: finalInput,
         temperature: titleGeneration ? 0.5 : 0.7, // Lower temperature for more predictable titles
         max_tokens: titleGeneration ? 20 : undefined, // Limit token count for titles
         stream: streamRequested,


### PR DESCRIPTION
## Summary
- adjust supabase chat function to send `input` object to the OpenAI responses API
- update `useMessageHandler` hook to pass messages inside `input`

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*