### PR TITLE
Fix OpenAI Responses call

### DIFF
--- a/src/hooks/useMessageHandler.ts
+++ b/src/hooks/useMessageHandler.ts
@@ -71,7 +71,7 @@ export const useMessageHandler = (
               apikey: anon,
               ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {})
             },
-            body: JSON.stringify({ input: { messages: openaiMessages } }),
+            body: JSON.stringify({ input: openaiMessages }),
             signal: controller.signal
           }
         );

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -30,9 +30,9 @@ serve(async (req) => {
       titleGeneration = false,
     } = await req.json();
 
-    const finalInput = input || { messages };
+    const finalInput = input || messages;
 
-    if (!finalInput?.messages || !Array.isArray(finalInput.messages)) {
+    if (!finalInput || !Array.isArray(finalInput)) {
       throw new Error('Invalid or missing messages array');
     }
 


### PR DESCRIPTION
## Summary
- fix OpenAI API call formatting in chat edge function
- update message handler to send an array instead of an object

## Testing
- `npx vitest` *(fails: request to https://registry.npmjs.org/vitest failed)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*