### PR TITLE
Fix chat function error from deprecated max_tokens param

### DIFF
--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -46,7 +46,8 @@ serve(async (req) => {
         model: model,
         input: finalInput,
         temperature: titleGeneration ? 0.5 : 0.7, // Lower temperature for more predictable titles
-        max_tokens: titleGeneration ? 20 : undefined, // Limit token count for titles
+        // The responses API no longer accepts the max_tokens parameter
+        // so we simply rely on the prompt to keep titles short.
         stream: streamRequested,
       })
     });


### PR DESCRIPTION
## Summary
- remove deprecated `max_tokens` when calling OpenAI responses endpoint
- add note explaining that the API no longer accepts this param

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*