### PR TITLE
Fix OpenAI response API fetches

### DIFF
--- a/supabase/functions/generate-chat-name/index.ts
+++ b/supabase/functions/generate-chat-name/index.ts
@@ -51,11 +51,14 @@ serve(async (req) => {
     });
 
     if (!createResp.ok) {
-      const err = await createResp.json();
-      return new Response(JSON.stringify(err), {
-        status: 500,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+      console.error("OpenAI error", await createResp.text());
+      return new Response(
+        JSON.stringify({ error: "Upstream OpenAI error" }),
+        {
+          status: 502,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
     const creation = await createResp.json();
@@ -72,19 +75,20 @@ serve(async (req) => {
 
     let data;
     for (let i = 0; i < 30; i++) {
-      const finished = await fetch(
-        `${OPENAI_BASE}/v1/responses/${responseId}`,
-        {
-          headers: openaiHeaders(apiKey),
-        },
-      );
+      const retrieveUrl = `${OPENAI_BASE}/v1/responses/${responseId}`;
+      const finished = await fetch(retrieveUrl, {
+        headers: openaiHeaders(apiKey),
+      });
 
       if (!finished.ok) {
-        const err = await finished.json();
-        return new Response(JSON.stringify(err), {
-          status: 500,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
+        console.error("OpenAI error", await finished.text());
+        return new Response(
+          JSON.stringify({ error: "Upstream OpenAI error" }),
+          {
+            status: 502,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
       }
 
       data = await finished.json();


### PR DESCRIPTION
## Summary
- patch chat and generate-chat-name edge functions
- use the helper for base URL and auth headers
- guard non-OK responses and return 502
- switch retrieve calls to a constant `retrieveUrl`

## Testing
- `npx vitest run` *(fails: connect EHOSTUNREACH)*