### PR TITLE
Fix SSE header for chat streaming

### DIFF
--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -11,6 +11,13 @@ function openaiHeaders(apiKey: string) {
   };
 }
 
+function sseHeaders(apiKey: string) {
+  return {
+    ...openaiHeaders(apiKey),
+    Accept: "text/event-stream",
+  };
+}
+
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers":
@@ -77,7 +84,7 @@ serve(async (req) => {
     if (streamRequested) {
       const events = await fetch(
         `${OPENAI_BASE}/v1/responses/${responseId}/events`,
-        { headers: openaiHeaders(apiKey) },
+        { headers: sseHeaders(apiKey) },
       );
 
       if (!events.ok) {


### PR DESCRIPTION
## Summary
- add `sseHeaders` helper for SSE request headers
- use SSE headers for streaming events

## Testing
- `npx vitest` *(fails: connect EHOSTUNREACH)*