### PR TITLE
Fix chat responses API request

### DIFF
--- a/src/hooks/useMessageHandler.ts
+++ b/src/hooks/useMessageHandler.ts
@@ -71,7 +71,7 @@ export const useMessageHandler = (
               apikey: anon,
               ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {})
             },
-            body: JSON.stringify({ messages: openaiMessages }),
+            body: JSON.stringify({ input: openaiMessages }),
             signal: controller.signal
           }
         );

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -58,7 +58,7 @@ serve(async (req) => {
       headers: openaiHeaders(apiKey),
       body: JSON.stringify({
         model,
-        messages: finalMessages,
+        input: finalMessages,
         store: true,
       }),
     });

--- a/supabase/functions/generate-chat-name/index.ts
+++ b/supabase/functions/generate-chat-name/index.ts
@@ -45,7 +45,7 @@ serve(async (req) => {
       headers: openaiHeaders(apiKey),
       body: JSON.stringify({
         model: "gpt-4o-mini",
-        messages: finalMessages,
+        input: finalMessages,
         store: true,
       }),
     });


### PR DESCRIPTION
## Summary
- use `input` parameter when calling responses API
- adjust frontend call to match new API

## Testing
- `npx vitest` *(fails: EHOSTUNREACH to registry)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*