### PR TITLE
Fix responses API integration

### DIFF
--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -60,6 +60,7 @@ serve(async (req) => {
         model,
         input: finalMessages,
         store: true,
+        ...(streamRequested ? { stream: true } : {}),
       }),
     });
 
@@ -144,7 +145,7 @@ serve(async (req) => {
         );
       }
 
-      const content = data.responses[0].message.content;
+      const content = data.output_text;
 
       return new Response(JSON.stringify({ content }), {
         headers: {

--- a/supabase/functions/generate-chat-name/index.ts
+++ b/supabase/functions/generate-chat-name/index.ts
@@ -108,7 +108,7 @@ serve(async (req) => {
       );
     }
 
-    const title = data.responses[0].message.content;
+    const title = data.output_text;
     return new Response(JSON.stringify({ title }), {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });


### PR DESCRIPTION
## Summary
- ensure streaming responses are enabled in chat function
- use `output_text` when returning completed responses

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find ESLint package)*