### PR TITLE
Add doc on OpenAI Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ VITE_OPENAI_MODEL=gpt-4o
 `VITE_OPENAI_MODEL` sets the model used by the edge functions when contacting
 OpenAI.
 
+## Preferred OpenAI API
+
+This project uses the **Responses API** for all OpenAI interactions. The older
+Completions endpoints are intentionally avoided. See
+[`docs/openai_api.md`](docs/openai_api.md) for details and links to official
+documentation.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/a746dae1-d079-4ba9-ad29-1a31653890b4) and click on Share -> Publish.

--- a/docs/openai_api.md
+++ b/docs/openai_api.md
@@ -1,0 +1,14 @@
+# Preferred OpenAI API Usage
+
+This project interacts with OpenAI exclusively through the **Responses API**. The earlier *Completions API* is considered legacy for this application and should not be used.
+
+Key points:
+
+- All requests are made to `https://api.openai.com/v1/responses`.
+- Edge functions automatically add the header `OpenAI-Beta: responses=auto` so requests are routed correctly.
+- Chat messages are sent as `input` arrays of messages rather than a single `prompt` string.
+- Responses may be streamed from `GET /v1/responses/{id}/events` for realtime updates.
+
+For implementation examples, see the Supabase Edge Functions in [`supabase/functions`](../supabase/functions).
+
+Official documentation: [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses).


### PR DESCRIPTION
## Summary
- describe the preferred OpenAI API
- add a short doc on using the Responses API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*