### PR TITLE
Fix SSE streaming parse error

### DIFF
--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -80,13 +80,6 @@ serve(async (req) => {
       );
     }
 
-    const creation = await createResp.json();
-    const responseId = creation.id;
-
-    if (!responseId) {
-      throw new Error("Invalid response ID from OpenAI");
-    }
-
     if (streamRequested) {
       return new Response(createResp.body, {
         headers: {
@@ -95,6 +88,13 @@ serve(async (req) => {
           "Cache-Control": "no-cache",
         },
       });
+    }
+
+    const creation = await createResp.json();
+    const responseId = creation.id;
+
+    if (!responseId) {
+      throw new Error("Invalid response ID from OpenAI");
     }
 
     // Poll for completion


### PR DESCRIPTION
## Summary
- fix streaming in edge function so JSON parsing isn't attempted when the response is streamed

## Testing
- `npm run test` *(fails: vitest not found)*