### PR TITLE
Fix chat API URL and front-end route

### DIFF
--- a/src/hooks/useMessageHandler.ts
+++ b/src/hooks/useMessageHandler.ts
@@ -62,19 +62,17 @@ export const useMessageHandler = (
 
         timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-        const response = await fetch(
-          `${supabaseUrl}/functions/v1/chat?stream=true`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              apikey: anon,
-              ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {})
-            },
-            body: JSON.stringify({ input: openaiMessages }),
-            signal: controller.signal
-          }
-        );
+        const url = `${supabaseUrl}/functions/v1/chat`;
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            apikey: anon,
+            ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {})
+          },
+          body: JSON.stringify({ input: openaiMessages, stream: true }),
+          signal: controller.signal
+        });
 
         clearTimeout(timeout);
 

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -98,10 +98,15 @@ serve(async (req) => {
   }
 
   if (stream) {
-    const eventsResp = await fetch(
-      `${OPENAI_BASE}/v1/responses/${responseId}/events`,
-      { headers: sseHeaders(apiKey) },
-    );
+    const eventsUrl =
+      `https://api.openai.com/v1/responses/${responseId}/events`;
+    console.log("Fetching", eventsUrl);
+    const eventsResp = await fetch(eventsUrl, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "text/event-stream",
+      },
+    });
     if (!eventsResp.ok || !eventsResp.body) {
       return errorResponse(eventsResp.status, await eventsResp.text());
     }


### PR DESCRIPTION
## Summary
- use an absolute OpenAI URL and log it in the chat edge function
- call the chat edge function without query params in useMessageHandler

## Testing
- `npm test` *(fails: vitest not found)*