### PR TITLE
Fix redirect handling and add runtime config

### DIFF
--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { CardContent, CardFooter } from "@/components/ui/card";
-import { supabase } from '@/integrations/supabase/client';
+import { getSupabase } from '@/lib/supa';
 import { toast } from '@/components/ui/use-toast';
 import { useNavigate } from 'react-router-dom';
 
@@ -18,6 +18,7 @@ const SignInForm: React.FC = () => {
     setLoading(true);
     
     try {
+      const supabase = await getSupabase();
       const { data, error } = await supabase.auth.signInWithPassword({
         email,
         password,

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -4,7 +4,7 @@ import { differenceInYears } from "date-fns";
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { CardContent, CardFooter } from "@/components/ui/card";
-import { supabase } from '@/integrations/supabase/client';
+import { getSupabase } from '@/lib/supa';
 import { toast } from '@/components/ui/use-toast';
 import DateOfBirthInput from './DateOfBirthInput';
 
@@ -52,6 +52,7 @@ const SignUpForm: React.FC = () => {
     setLoading(true);
     
     try {
+      const supabase = await getSupabase();
       const { error, data } = await supabase.auth.signUp({
         email,
         password,

--- a/src/components/profile/ChildAccountsSection.tsx
+++ b/src/components/profile/ChildAccountsSection.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useFeatureAccess } from '@/hooks/useFeatureAccess';
 import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
+import { getSupabase } from '@/lib/supa';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -29,6 +29,7 @@ const ChildAccountsSection: React.FC = () => {
   const fetchChildren = async () => {
     if (!user) return;
     setLoading(true);
+    const supabase = await getSupabase();
     try {
       const { data, error } = await supabase
         .from('profiles')
@@ -73,6 +74,7 @@ const ChildAccountsSection: React.FC = () => {
 
   const handleUpdateMessage = async (childId: string, message: string) => {
     try {
+      const supabase = await getSupabase();
       const { error } = await supabase
         .from('profiles')
         .update({ system_message: message })

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -8,7 +8,7 @@ import { useChatSessions } from '@/hooks/chatSessions';
 import { useChatNameGenerator } from '@/hooks/useChatNameGenerator';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/components/ui/use-toast';
-import { supabase } from '@/integrations/supabase/client';
+import { getSupabase } from '@/lib/supa';
 import {
   DEFAULT_ADULT_SYSTEM_MESSAGE,
   getDefaultSystemMessage
@@ -28,6 +28,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const fetchSystemMessage = async () => {
       if (!user) return;
 
+      const supabase = await getSupabase();
       const { data, error } = await supabase
         .from('profiles')
         .select('system_message, user_role')
@@ -200,6 +201,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
     try {
       // Check if user has adult role
+      const supabase = await getSupabase();
       const { data: profileData, error: profileError } = await supabase
         .from('profiles')
         .select('user_role, system_message')

--- a/src/hooks/__tests__/useChatStream.nonstream.test.ts
+++ b/src/hooks/__tests__/useChatStream.nonstream.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi } from 'vitest';
 import { useChatStream } from '../useChatStream';
 import { renderHook, act } from '@testing-library/react';
 
-vi.mock('@/integrations/supabase/client', () => ({
-  supabase: { auth: { getSession: vi.fn().mockResolvedValue({ data: { session: { access_token: 't' } } }) } }
+vi.mock('@/lib/supa', () => ({
+  getSupabase: async () => ({ auth: { getSession: vi.fn().mockResolvedValue({ data: { session: { access_token: 't' } } }) } })
 }));
 
 global.fetch = vi.fn().mockResolvedValue({

--- a/src/hooks/chatSessions/useChatDatabase.ts
+++ b/src/hooks/chatSessions/useChatDatabase.ts
@@ -2,12 +2,13 @@
 import { useCallback } from 'react';
 import { Message } from '@/types/chat';
 import { ChatSession } from '@/types/chatContext';
-import { supabase } from '@/integrations/supabase/client';
+import { getSupabase } from '@/lib/supa';
 
 export const useChatDatabase = () => {
   // Fetch all sessions for a user. If no userId is provided, use the
   // currently authenticated user.
   const fetchUserSessions = useCallback(async (userId?: string) => {
+    const supabase = await getSupabase();
     if (!userId) {
       const {
         data: { user },
@@ -68,6 +69,7 @@ export const useChatDatabase = () => {
 
   // Create a new chat in the database
   const createNewChatInDb = useCallback(async (userId: string) => {
+    const supabase = await getSupabase();
     if (!userId) {
       throw new Error('User must be logged in to create a chat');
     }
@@ -129,6 +131,7 @@ export const useChatDatabase = () => {
 
   // Update a chat name in the database
   const updateChatNameInDb = useCallback(async (chatId: string, userId: string, newName: string) => {
+    const supabase = await getSupabase();
     try {
       const { error } = await supabase
         .from('chat_sessions')
@@ -146,6 +149,7 @@ export const useChatDatabase = () => {
 
   // Set the initial chat name using a SECURITY DEFINER function
   const initializeSessionName = useCallback(async (chatId: string, name: string) => {
+    const supabase = await getSupabase();
     try {
       const { error } = await supabase.rpc('set_session_name', {
         _session_id: chatId,
@@ -162,6 +166,7 @@ export const useChatDatabase = () => {
 
   // Update session timestamp in the database
   const updateSessionTimestampInDb = useCallback(async (chatId: string, userId: string) => {
+    const supabase = await getSupabase();
     try {
       const { error } = await supabase
         .from('chat_sessions')
@@ -179,6 +184,7 @@ export const useChatDatabase = () => {
 
   // Save a message to the database
   const saveMessageToDb = useCallback(async (chatId: string, message: Message) => {
+    const supabase = await getSupabase();
     try {
       const { data, error } = await supabase
         .from('chat_messages')

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
-import { supabase } from '@/integrations/supabase/client';
+import { getSupabase } from '@/lib/supa';
+import { getRuntimeConfig } from '@/lib/runtimeConfig';
 
 export async function parseSseStream(
   stream: ReadableStream<Uint8Array>,
@@ -56,12 +57,11 @@ export const useChatStream = () => {
     const controller = new AbortController();
     ctrlRef.current = controller;
 
+    const supabase = await getSupabase();
     const { data } = await supabase.auth.getSession();
     const access = data.session?.access_token;
-    const anon =
-      import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-      import.meta.env.VITE_SUPABASE_ANON_KEY;
-    const url = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/chat`;
+    const { supabaseUrl, supabaseAnonKey: anon } = await getRuntimeConfig();
+    const url = `${supabaseUrl}/functions/v1/chat`;
 
     const resp = await fetch(url, {
       method: 'POST',

--- a/src/hooks/useMessageHandler.ts
+++ b/src/hooks/useMessageHandler.ts
@@ -3,7 +3,8 @@ import { useState, useRef, useEffect } from 'react';
 
 const FETCH_TIMEOUT_MS = 30000; // Abort streaming if no response within 30s
 import { Message } from '@/types/chat';
-import { supabase } from '@/integrations/supabase/client';
+import { getSupabase } from '@/lib/supa';
+import { getRuntimeConfig } from '@/lib/runtimeConfig';
 import { toast } from '@/components/ui/use-toast';
 import { DEFAULT_ADULT_SYSTEM_MESSAGE } from '@/config/systemMessages';
 
@@ -55,8 +56,8 @@ export const useMessageHandler = (
         // Debugging: log the full prompt (system + user)
         console.log('Full prompt to OpenAI:', openaiMessages);
 
-        const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-        const anon = import.meta.env.VITE_SUPABASE_ANON_KEY;
+        const { supabaseUrl, supabaseAnonKey: anon } = await getRuntimeConfig();
+        const supabase = await getSupabase();
         const session = await supabase.auth.getSession();
         const accessToken = session.data.session?.access_token;
 

--- a/src/hooks/useUserPermissions.ts
+++ b/src/hooks/useUserPermissions.ts
@@ -1,7 +1,7 @@
 
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
+import { getSupabase } from '@/lib/supa';
 import { UserPermissions, UserRole, SubscriptionTier, UserFeatureAccess } from '@/types/userTypes';
 
 export const useUserPermissions = (): {
@@ -36,6 +36,7 @@ export const useUserPermissions = (): {
       }
       
       try {
+        const supabase = await getSupabase();
         const { data: profileData, error: profileError } = await supabase
           .from('profiles')
           .select('user_role, subscription_tier, system_message')

--- a/src/lib/runtimeConfig.ts
+++ b/src/lib/runtimeConfig.ts
@@ -1,0 +1,7 @@
+let cached: { supabaseUrl: string; supabaseAnonKey: string } | null = null;
+export async function getRuntimeConfig() {
+  if (cached) return cached;
+  const r = await fetch("/functions/v1/config");
+  cached = await r.json();
+  return cached;
+}

--- a/src/lib/supa.ts
+++ b/src/lib/supa.ts
@@ -1,0 +1,12 @@
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "@/integrations/supabase/types";
+import { getRuntimeConfig } from "./runtimeConfig";
+
+let client: ReturnType<typeof createClient<Database>> | null = null;
+
+export async function getSupabase() {
+  if (client) return client;
+  const { supabaseUrl, supabaseAnonKey } = await getRuntimeConfig();
+  client = createClient<Database>(supabaseUrl, supabaseAnonKey);
+  return client;
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useChat } from '@/contexts/ChatContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/components/ui/use-toast';
-import { supabase } from '@/integrations/supabase/client';
+import { getSupabase } from '@/lib/supa';
 import { DEFAULT_ADULT_SYSTEM_MESSAGE, getDefaultSystemMessage } from '@/config/systemMessages';
 
 // Import refactored components
@@ -32,6 +32,8 @@ const Profile: React.FC = () => {
   useEffect(() => {
     const fetchProfile = async () => {
       if (!user) return;
+
+      const supabase = await getSupabase();
       
       try {
         const { data, error } = await supabase
@@ -61,9 +63,11 @@ const Profile: React.FC = () => {
   
   const handleProfileUpdate = async () => {
     if (!user) return;
-    
+
     try {
       setLoading(true);
+
+      const supabase = await getSupabase();
       
       // If updating email, check that it's not already used
       if (email !== user.email) {

--- a/src/utils/chatNameGenerator.ts
+++ b/src/utils/chatNameGenerator.ts
@@ -1,9 +1,10 @@
 
 import { Message } from '@/types/chat';
-import { supabase } from '@/integrations/supabase/client';
+import { getSupabase } from '@/lib/supa';
 
 export const generateChatName = async (messages: Message[]): Promise<string> => {
   try {
+    const supabase = await getSupabase();
     // Format messages for the API
     const chatHistory = messages.map(msg => ({
       role: msg.isUser ? 'user' : 'assistant',

--- a/src/utils/createChildAccount.ts
+++ b/src/utils/createChildAccount.ts
@@ -1,6 +1,7 @@
-import { supabase } from '@/integrations/supabase/client';
+import { getSupabase } from '@/lib/supa';
 
 export const createChildAccount = async (email: string, password: string) => {
+  const supabase = await getSupabase();
   const { data, error } = await supabase.functions.invoke('create-child-account', {
     body: { email, password }
   });

--- a/src/utils/voice/voiceConnection.ts
+++ b/src/utils/voice/voiceConnection.ts
@@ -1,5 +1,6 @@
 
 import { VoiceSessionState } from '@/types/voiceSession';
+import { getRuntimeConfig } from '@/lib/runtimeConfig';
 
 /**
  * Creates a WebSocket connection to the OpenAI realtime API via our Supabase edge function
@@ -12,10 +13,9 @@ export const createVoiceWebSocket = async (
   onClose?: () => void
 ): Promise<WebSocket | null> => {
   try {
-    // Build the WebSocket URL from Supabase env vars
-    const http = import.meta.env.VITE_SUPABASE_URL;
-    const wsBase = http.replace(/^https?/, 'wss');
-    const anon = import.meta.env.VITE_SUPABASE_ANON_KEY;
+    // Build the WebSocket URL from runtime config
+    const { supabaseUrl, supabaseAnonKey: anon } = await getRuntimeConfig();
+    const wsBase = supabaseUrl.replace(/^https?/, 'wss');
     const supabaseRealtimeEndpoint = `${wsBase}/functions/v1/realtime-chat?apikey=${anon}`;
     
     console.log('Creating WebSocket connection to:', supabaseRealtimeEndpoint);

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,5 @@
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -109,7 +109,9 @@ serve(async (req) => {
     if (eventsResp.status >= 300 && eventsResp.status < 400) {
       const loc = eventsResp.headers.get("location");
       if (loc) {
-        const newUrl = loc.startsWith("http") ? loc : `${OPENAI_BASE}${loc}`;
+        const newUrl = loc.startsWith("http")
+          ? loc
+          : `https://api.openai.com${loc}`;
         eventsResp = await fetch(newUrl, {
           headers: {
             Authorization: `Bearer ${apiKey}`,

--- a/supabase/functions/config/index.ts
+++ b/supabase/functions/config/index.ts
@@ -1,0 +1,10 @@
+import { corsHeaders } from "../_shared/cors.ts";
+Deno.serve((_req) =>
+  new Response(
+    JSON.stringify({
+      supabaseUrl: Deno.env.get("SUPABASE_URL"),
+      supabaseAnonKey: Deno.env.get("SUPABASE_ANON_KEY"),
+    }),
+    { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+  ),
+);


### PR DESCRIPTION
## Summary
- fix OpenAI redirect logic in chat function
- propagate upstream error status
- expose runtime config via `/functions/v1/config`
- lazy load Supabase credentials at runtime
- update all frontend code to use the runtime config

## Testing
- `npm test` *(fails: vitest not found)*