### PR TITLE
fix runtime config url

### DIFF
--- a/src/lib/runtimeConfig.ts
+++ b/src/lib/runtimeConfig.ts
@@ -1,7 +1,10 @@
 let cached: { supabaseUrl: string; supabaseAnonKey: string } | null = null;
 export async function getRuntimeConfig() {
   if (cached) return cached;
-  const r = await fetch("/functions/v1/config");
+  const projectRef = "xrrauvcciuiaztzajmeq"; // TODO: env or derive from anon key
+  const r = await fetch(
+    `https://${projectRef}.supabase.co/functions/v1/config`
+  );
   cached = await r.json();
   return cached;
 }


### PR DESCRIPTION
## Summary
- fetch runtime config from Supabase project domain rather than site domain

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*