### PR TITLE
Make runtime config endpoint public

### DIFF
--- a/supabase/functions/config/index.ts
+++ b/supabase/functions/config/index.ts
@@ -1,10 +1,18 @@
 import { corsHeaders } from "../_shared/cors.ts";
-Deno.serve((_req) =>
-  new Response(
-    JSON.stringify({
-      supabaseUrl: Deno.env.get("SUPABASE_URL"),
-      supabaseAnonKey: Deno.env.get("SUPABASE_ANON_KEY"),
-    }),
-    { headers: { ...corsHeaders, "Content-Type": "application/json" } },
-  ),
-);
+
+// Public function returning Supabase runtime configuration
+Deno.serve((req) => {
+  // Handle CORS preflight requests
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  const body = {
+    supabaseUrl: Deno.env.get("SUPABASE_URL"),
+    supabaseAnonKey: Deno.env.get("SUPABASE_ANON_KEY"),
+  };
+
+  return new Response(JSON.stringify(body), {
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+});


### PR DESCRIPTION
## Summary
- make `/functions/v1/config` public with CORS handling

## Testing
- `npm test` *(fails: `vitest: not found`)*