### PR TITLE
Make runtime config public

### DIFF
--- a/src/lib/runtimeConfig.ts
+++ b/src/lib/runtimeConfig.ts
@@ -2,9 +2,7 @@ let cached: { supabaseUrl: string; supabaseAnonKey: string } | null = null;
 export async function getRuntimeConfig() {
   if (cached) return cached;
   const projectRef = "xrrauvcciuiaztzajmeq"; // TODO: env or derive from anon key
-  const r = await fetch(
-    `https://${projectRef}.supabase.co/functions/v1/config`
-  );
+  const r = await fetch("/functions/v1/config");
   cached = await r.json();
   return cached;
 }

--- a/supabase/functions/config/index.ts
+++ b/supabase/functions/config/index.ts
@@ -1,18 +1,11 @@
 import { corsHeaders } from "../_shared/cors.ts";
 
-// Public function returning Supabase runtime configuration
-Deno.serve((req) => {
-  // Handle CORS preflight requests
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
-  }
-
-  const body = {
-    supabaseUrl: Deno.env.get("SUPABASE_URL"),
-    supabaseAnonKey: Deno.env.get("SUPABASE_ANON_KEY"),
-  };
-
-  return new Response(JSON.stringify(body), {
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
-  });
-});
+Deno.serve((_req) =>
+  new Response(
+    JSON.stringify({
+      supabaseUrl: Deno.env.get("SUPABASE_URL"),
+      supabaseAnonKey: Deno.env.get("SUPABASE_ANON_KEY"),
+    }),
+    { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+  ),
+);


### PR DESCRIPTION
## Summary
- make `/functions/v1/config` not require auth
- load runtime config from the relative path

## Testing
- `npm test` *(fails: vitest not found)*