### PR TITLE
Proxy Supabase edge functions

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,3 @@
+/functions/v1/*  https://xrrauvcciuiaztzajmeq.supabase.co/functions/v1/:splat  200
+
+# keep any other redirects below

--- a/src/lib/runtimeConfig.ts
+++ b/src/lib/runtimeConfig.ts
@@ -1,8 +1,13 @@
+const SUPABASE_ANON =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InhycmF1dmNjaXVpYXp0emFqbWVxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY3NDI3MTIsImV4cCI6MjA2MjMxODcxMn0.09L9ry63W4ivDZZKk1HMpLJeinZ-TUmeWdja9byANEM";
+
 let cached: { supabaseUrl: string; supabaseAnonKey: string } | null = null;
 export async function getRuntimeConfig() {
   if (cached) return cached;
-  const projectRef = "xrrauvcciuiaztzajmeq"; // TODO: env or derive from anon key
-  const r = await fetch("/functions/v1/config");
+  const r = await fetch("/functions/v1/config", {
+    headers: { apikey: SUPABASE_ANON },
+  });
+  if (!r.ok) throw new Error("runtime config fetch failed");
   cached = await r.json();
   return cached;
 }


### PR DESCRIPTION
## Summary
- proxy `/functions/v1/*` to Supabase edge functions using Netlify redirects
- fetch runtime config with an API key header and error handling

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*