### PR TITLE
Fix SSE token parsing

### DIFF
--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -29,7 +29,10 @@ export async function parseSseStream(
             onImage?.(payload.url);
           } else {
             const delta =
-              payload.delta ?? payload.response?.delta?.content ?? '';
+              payload.delta ??
+              payload.response?.delta?.content ??
+              payload.choices?.[0]?.delta?.content ??
+              '';
             if (delta) onToken?.(delta);
           }
         } catch (err) {

--- a/src/hooks/useMessageHandler.ts
+++ b/src/hooks/useMessageHandler.ts
@@ -115,7 +115,11 @@ export const useMessageHandler = (
               }
               try {
                 const json = JSON.parse(dataStr);
-                const token = json.response?.delta?.content || '';
+                const token =
+                  json.choices?.[0]?.delta?.content ||
+                  json.delta ||
+                  json.response?.delta?.content ||
+                  '';
                 if (token) {
                   currentContent += token;
                   setMessages(prev => {


### PR DESCRIPTION
## Summary
- update chat stream and message handlers to parse Chat Completions tokens

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*