### PR TITLE
Add image generation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ Automated CI workflows handle Supabase deploys and migrations.
 - Multimodal image packets
 - Voice TTS responses
 - Agentic function calls
+- Replace manual image generation invocation with agentic workflow

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useRef } from 'react';
-import { Send, Loader2, Mic } from 'lucide-react';
+import { Send, Loader2, Mic, Image as ImageIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useChat } from '@/contexts/ChatContext';
@@ -9,12 +9,16 @@ interface MessageInputProps {
   onSendMessage: (message: string) => void;
   onVoiceButtonClick?: () => void;
   showVoiceButton?: boolean;
+  onGenerateImage?: (prompt: string) => void;
+  showImageButton?: boolean;
 }
 
-const MessageInput: React.FC<MessageInputProps> = ({ 
-  onSendMessage, 
-  onVoiceButtonClick, 
-  showVoiceButton = true 
+const MessageInput: React.FC<MessageInputProps> = ({
+  onSendMessage,
+  onVoiceButtonClick,
+  showVoiceButton = true,
+  onGenerateImage,
+  showImageButton = false
 }) => {
   const [message, setMessage] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
@@ -25,6 +29,15 @@ const MessageInput: React.FC<MessageInputProps> = ({
       onSendMessage(message);
       setMessage('');
       // Keep focus on the text entry for follow-up messages
+      inputRef.current?.focus();
+    }
+  };
+
+  const handleGenerateImage = () => {
+    if (!onGenerateImage) return;
+    if (message.trim()) {
+      onGenerateImage(message);
+      setMessage('');
       inputRef.current?.focus();
     }
   };
@@ -51,14 +64,26 @@ const MessageInput: React.FC<MessageInputProps> = ({
       
       {/* Only show the voice button if the feature is enabled */}
       {showVoiceButton && onVoiceButtonClick && (
-        <Button 
-          className="bg-hero/80 hover:bg-hero text-white" 
-          size="icon" 
+        <Button
+          className="bg-hero/80 hover:bg-hero text-white"
+          size="icon"
           onClick={onVoiceButtonClick}
           disabled={isWaitingForResponse}
           title="Start voice conversation"
         >
           <Mic size={18} />
+        </Button>
+      )}
+
+      {showImageButton && onGenerateImage && (
+        <Button
+          className="bg-hero/80 hover:bg-hero text-white"
+          size="icon"
+          onClick={handleGenerateImage}
+          disabled={!message.trim() || isWaitingForResponse}
+          title="Generate image"
+        >
+          <ImageIcon size={18} />
         </Button>
       )}
       

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -53,6 +53,8 @@ const MessageList: React.FC<MessageListProps> = ({ messages }) => {
         >
           {message.isUser ? (
             message.content
+          ) : message.imageUrl ? (
+            <img src={message.imageUrl} alt="Generated" className="max-w-full rounded" />
           ) : (
             <div className="prose prose-sm dark:prose-invert">
               <ReactMarkdown components={{

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,10 +14,11 @@ import { useFeatureFlags } from '@/hooks/useFeatureFlags';
 const Index: React.FC = () => {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isVoiceModeActive, setIsVoiceModeActive] = useState(false);
-  const { 
-    messages, 
-    addMessage, 
-    heroColor, 
+  const {
+    messages,
+    addMessage,
+    generateImage,
+    heroColor,
     setHeroColor,
     createNewChat
   } = useChat();
@@ -35,6 +36,10 @@ const Index: React.FC = () => {
 
   const handleSendMessage = (message: string) => {
     addMessage(message, true);
+  };
+
+  const handleGenerateImage = (prompt: string) => {
+    generateImage(prompt);
   };
 
   const toggleVoiceMode = () => {
@@ -92,10 +97,12 @@ const Index: React.FC = () => {
         </main>
         
         <div className="fixed bottom-0 left-0 right-0">
-          <MessageInput 
-            onSendMessage={handleSendMessage} 
+          <MessageInput
+            onSendMessage={handleSendMessage}
             onVoiceButtonClick={toggleVoiceMode}
             showVoiceButton={isEnabled('voiceMode')}
+            onGenerateImage={handleGenerateImage}
+            showImageButton={isEnabled('imageGeneration')}
           />
         </div>
       </div>

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -3,6 +3,7 @@ export interface Message {
   content: string;
   isUser: boolean;
   timestamp?: number;
+  imageUrl?: string;
   role?: 'user' | 'assistant' | 'system';
 }
 

--- a/src/types/chatContext.ts
+++ b/src/types/chatContext.ts
@@ -14,6 +14,7 @@ export interface ChatContextType {
   heroColor: string;
   setHeroColor: (color: string) => void;
   isWaitingForResponse: boolean;
+  generateImage: (prompt: string) => void;
   systemMessage: string;
   chatName: string | null;
   chatSessions: ChatSession[];

--- a/supabase/functions/generate-image/index.ts
+++ b/supabase/functions/generate-image/index.ts
@@ -1,0 +1,64 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+function errorResponse(status: number, msg: string) {
+  return new Response(JSON.stringify({ error: msg }), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const apiKey = Deno.env.get("OPENAI_API_KEY");
+  if (!apiKey) {
+    return errorResponse(503, "OpenAI API key not configured");
+  }
+
+  let body: { prompt?: string };
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+
+  const prompt = body.prompt;
+  if (!prompt) {
+    return errorResponse(400, "Missing prompt");
+  }
+
+  const openaiResp = await fetch(
+    "https://api.openai.com/v1/images/generations",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-image-1",
+        prompt,
+      }),
+    },
+  );
+
+  if (!openaiResp.ok) {
+    const text = await openaiResp.text();
+    return errorResponse(openaiResp.status, text);
+  }
+
+  const data = await openaiResp.json();
+  const url = data.data?.[0]?.url;
+  return new Response(JSON.stringify({ url }), {
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+});


### PR DESCRIPTION
## Summary
- add new `generate-image` edge function using GPT-Image-1
- extend message type to include `imageUrl`
- enable image messages in chat context and UI
- provide image send button behind `imageGeneration` feature flag
- update roadmap

## Testing
- `bun test` *(fails: Cannot find package 'react')*