### PR TITLE
Implement session lifecycle edge functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ netlify deploy --prod
 
 Supabase edge functions are deployed separately using the `supabase` CLI (see quick start above).
 
+### Edge functions
+
+| Endpoint | Purpose |
+| -------- | ------- |
+| `/functions/v1/hideSession` | Mark a chat session as hidden |
+| `/functions/v1/deleteSession` | Soft delete a chat session |
+
+Example request:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{"id":"uuid"}' \
+  https://<project>.supabase.co/functions/v1/hideSession
+```
+
 ### GitHub Actions
 
 Automated CI workflows handle Supabase deploys and migrations.

--- a/src/components/ChatSessionRow.tsx
+++ b/src/components/ChatSessionRow.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { EyeOff, Trash2 } from "lucide-react";
 import { supabase } from "@/lib/supa";
+import { toast } from "@/components/ui/use-toast";
 
 interface Props {
   session: { id: string; title: string };
@@ -10,6 +11,36 @@ interface Props {
 export default function ChatSessionRow({ session, onSelect }: Props) {
   const [show, setShow] = useState(false);
   const toggle = () => setShow((v) => !v);
+
+  const hide = async () => {
+    const { error } = await supabase.functions.invoke("hideSession", {
+      body: { id: session.id },
+    });
+    if (error) {
+      toast({
+        title: "Failed to hide chat",
+        description: error.message,
+        variant: "destructive",
+      });
+    } else {
+      toast({ title: "Chat hidden" });
+    }
+  };
+
+  const remove = async () => {
+    const { error } = await supabase.functions.invoke("deleteSession", {
+      body: { id: session.id },
+    });
+    if (error) {
+      toast({
+        title: "Failed to delete chat",
+        description: error.message,
+        variant: "destructive",
+      });
+    } else {
+      toast({ title: "Chat deleted" });
+    }
+  };
 
   return (
     <li
@@ -26,7 +57,7 @@ export default function ChatSessionRow({ session, onSelect }: Props) {
           aria-label="Hide session"
           onClick={(e) => {
             e.stopPropagation();
-            supabase.functions.invoke("hideSession", { id: session.id });
+            hide();
           }}
           className="p-1 rounded hover:bg-muted pointer-events-auto"
         >
@@ -36,7 +67,7 @@ export default function ChatSessionRow({ session, onSelect }: Props) {
           aria-label="Delete session"
           onClick={(e) => {
             e.stopPropagation();
-            supabase.functions.invoke("deleteSession", { id: session.id });
+            remove();
           }}
           className="p-1 rounded hover:bg-destructive/20 pointer-events-auto"
         >

--- a/supabase/functions/deleteSession/index.ts
+++ b/supabase/functions/deleteSession/index.ts
@@ -1,0 +1,47 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { corsHeaders } from "../_shared/cors.ts";
+
+function jsonResponse(payload: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  if (!supabaseUrl || !anonKey) {
+    return jsonResponse({ error: "Missing Supabase env vars" }, 500);
+  }
+
+  const supabase = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: req.headers.get("authorization")! } },
+  });
+
+  let body: { id?: string };
+  try { body = await req.json(); } catch { body = {}; }
+
+  if (!body.id) {
+    return jsonResponse({ error: "id required" }, 400);
+  }
+
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userData?.user) {
+    return jsonResponse({ error: "Unauthorized" }, 401);
+  }
+
+  const { error } = await supabase
+    .from("chat_sessions")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("id", body.id)
+    .eq("user_id", userData.user.id);
+
+  if (error) return jsonResponse({ error: error.message }, 500);
+  return jsonResponse({ success: true });
+});

--- a/supabase/functions/hideSession/index.ts
+++ b/supabase/functions/hideSession/index.ts
@@ -1,0 +1,47 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { corsHeaders } from "../_shared/cors.ts";
+
+function jsonResponse(payload: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  if (!supabaseUrl || !anonKey) {
+    return jsonResponse({ error: "Missing Supabase env vars" }, 500);
+  }
+
+  const supabase = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: req.headers.get("authorization")! } },
+  });
+
+  let body: { id?: string };
+  try { body = await req.json(); } catch { body = {}; }
+
+  if (!body.id) {
+    return jsonResponse({ error: "id required" }, 400);
+  }
+
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userData?.user) {
+    return jsonResponse({ error: "Unauthorized" }, 401);
+  }
+
+  const { error } = await supabase
+    .from("chat_sessions")
+    .update({ hidden: true })
+    .eq("id", body.id)
+    .eq("user_id", userData.user.id);
+
+  if (error) return jsonResponse({ error: error.message }, 500);
+  return jsonResponse({ success: true });
+});

--- a/supabase/migrations/20250521120000_add_update_policy_chat_sessions.sql
+++ b/supabase/migrations/20250521120000_add_update_policy_chat_sessions.sql
@@ -1,0 +1,4 @@
+CREATE POLICY IF NOT EXISTS "Users can update their own sessions"
+  ON public.chat_sessions FOR UPDATE TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- add new `hideSession` and `deleteSession` edge functions
- allow users to hide or delete sessions through these endpoints
- handle success/error with toasts on the frontend
- document new endpoints and usage
- add RLS policy enabling users to update their own sessions

## Testing
- `bun run lint` *(fails: Cannot find package '@eslint/js')*
- `bun run test` *(fails: vitest: command not found)*