### PR TITLE
Fix session hide timestamp to use ISO format

### DIFF
--- a/supabase/functions/hideSession/index.ts
+++ b/supabase/functions/hideSession/index.ts
@@ -43,7 +43,10 @@ serve(async (req) => {
 
   const query = supabase
     .from("chat_sessions")
-    .update({ hidden: true })
+    .update({
+      hidden: true,
+      hidden_at: new Date().toISOString(),
+    })
     .eq("id", body.id);
 
   const { error } = await query;


### PR DESCRIPTION
## Summary
- timestamp session hiding with ISO string to avoid Postgres cast errors

## Testing
- `npm test` *(fails: vitest not found)*