### PR TITLE
Fix session hide/delete flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Supabase edge functions are deployed separately using the `supabase` CLI (see qu
 | Endpoint | Purpose |
 | -------- | ------- |
 | `/functions/v1/hideSession` | Mark a chat session as hidden |
-| `/functions/v1/deleteSession` | Soft delete a chat session |
+| `/functions/v1/deleteSession` | Delete a chat session |
 
 Example request:
 
@@ -68,6 +68,13 @@ curl -X POST \
   -d '{"id":"uuid"}' \
   https://<project>.supabase.co/functions/v1/hideSession
 ```
+
+### Session Lifecycle
+
+| Action | Behaviour |
+| ------ | --------- |
+| hide   | hidden=true, recoverable |
+| delete | removes session+messages |
 
 ### GitHub Actions
 

--- a/supabase/functions/hideSession/index.ts
+++ b/supabase/functions/hideSession/index.ts
@@ -44,10 +44,7 @@ serve(async (req) => {
   try {
     const { error } = await supabase
       .from("chat_sessions")
-      .update({
-        hidden: true,
-        hidden_at: new Date().toISOString(),
-      })
+      .update({ hidden: true })
       .eq("id", body.id);
 
     if (error) throw error;

--- a/supabase/migrations/20250521_add_hidden.sql
+++ b/supabase/migrations/20250521_add_hidden.sql
@@ -1,0 +1,6 @@
+-- Add soft-hide capability
+ALTER TABLE chat_sessions
+  ADD COLUMN hidden boolean NOT NULL DEFAULT false;
+
+-- (optional) Ensure deleted_at column exists for audit
+-- ALTER TABLE chat_sessions ADD COLUMN deleted_at timestamptz;


### PR DESCRIPTION
## Summary
- add hidden flag to chat sessions
- remove hidden_at usage from hideSession
- hard delete session and messages, generating name first
- document session lifecycle behaviors

See `docs/codex_guardrails.md` for guidelines.

### Codex Guardrail Checklist
- [ ] I ran `bun run test` and all suites pass.
- [ ] No env var or public API contract was renamed; if yes, I updated docs & affected code.
- [ ] For any DB change, I added a Supabase migration **and** RLS policy.
- [ ] I reproduced the original bug with a failing test and the test now passes.
- [ ] I manually tested streaming in the Netlify preview (desktop + mobile).
- [ ] I confirmed UI affordances match existing hover/tap behaviour.
- [ ] I updated `docs/codex_guardrails.md` if I introduced new patterns or learned lessons.