### PR TITLE
Implement optimistic session deletion

### DIFF
--- a/src/components/ChatSessionRow.tsx
+++ b/src/components/ChatSessionRow.tsx
@@ -34,6 +34,10 @@ export default function ChatSessionRow({ session, onSelect }: Props) {
 
   const remove = async () => {
     setDeleting(true);
+
+    // Optimistically remove the session so the row disappears immediately
+    removeSessionLocal(session.id);
+
     const { error } = await invokeWithAuth("deleteSession", { id: session.id });
     if (error) {
       toast({
@@ -42,7 +46,6 @@ export default function ChatSessionRow({ session, onSelect }: Props) {
         variant: "destructive",
       });
     } else {
-      removeSessionLocal(session.id);
       toast({ title: "Chat deleted" });
     }
     setDeleting(false);


### PR DESCRIPTION
## Summary
- improve deletion UX in `ChatSessionRow` by removing row before API call

## Testing
- `npm test` *(fails: vitest not found)*