### PR TITLE
Add mobile edge swipe to open side panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,4 @@ Automated CI workflows handle Supabase deploys and migrations.
 - Voice TTS responses
 - Agentic function calls
 - Replace manual image generation invocation with agentic workflow
+- Edge swipe from the left on mobile opens the settings panel

--- a/src/hooks/useEdgeSwipe.tsx
+++ b/src/hooks/useEdgeSwipe.tsx
@@ -1,0 +1,48 @@
+import { useRef, useEffect } from "react";
+import { useIsMobile } from "./use-mobile";
+
+const EDGE_THRESHOLD = 20; // px from the left edge to start swipe
+const SWIPE_THRESHOLD = 50; // distance required to trigger
+
+/**
+ * Detects a swipe from the left edge of the screen on mobile devices and
+ * invokes the provided callback.
+ */
+export function useEdgeSwipe(onSwipe: () => void) {
+  const isMobile = useIsMobile();
+  const startX = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isMobile) return;
+
+    const handleTouchStart = (e: TouchEvent) => {
+      if (e.touches.length === 1 && e.touches[0].clientX < EDGE_THRESHOLD) {
+        startX.current = e.touches[0].clientX;
+      }
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (startX.current !== null) {
+        const deltaX = e.touches[0].clientX - startX.current;
+        if (deltaX > SWIPE_THRESHOLD) {
+          onSwipe();
+          startX.current = null;
+        }
+      }
+    };
+
+    const handleTouchEnd = () => {
+      startX.current = null;
+    };
+
+    window.addEventListener("touchstart", handleTouchStart);
+    window.addEventListener("touchmove", handleTouchMove);
+    window.addEventListener("touchend", handleTouchEnd);
+
+    return () => {
+      window.removeEventListener("touchstart", handleTouchStart);
+      window.removeEventListener("touchmove", handleTouchMove);
+      window.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [onSwipe, isMobile]);
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Navigate } from 'react-router-dom';
 import { toast } from '@/components/ui/use-toast';
 import { useFeatureFlags } from '@/hooks/useFeatureFlags';
+import { useEdgeSwipe } from '@/hooks/useEdgeSwipe';
 
 const Index: React.FC = () => {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -24,6 +25,9 @@ const Index: React.FC = () => {
   } = useChat();
   const { session } = useAuth();
   const { isEnabled } = useFeatureFlags();
+
+  // Open the settings panel when the user swipes from the left edge on mobile
+  useEdgeSwipe(() => setIsSettingsOpen(true));
 
   // Additional check to ensure the user is authenticated
   if (!session) {


### PR DESCRIPTION
## Summary
- add new `useEdgeSwipe` hook to detect left edge swipe on mobile
- open the settings panel using the new hook in Index page
- document the mobile edge swipe behavior in the README

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm install` *(fails: EHOSTUNREACH)*