### PR TITLE
Add Vitest test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -84,6 +86,8 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
-    "vitest": "^1.5.0"
+    "vitest": "^1.5.0",
+    "@vitest/ui": "^1.5.0",
+    "@vitest/coverage-c8": "^1.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- add new test scripts for Vitest
- include `@vitest/ui` and `@vitest/coverage-c8` as dev dependencies

## Testing
- `npm test` *(fails: vitest not found)*