### PR TITLE
Fix image generator model

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ supabase functions deploy chat --project-ref <project-id>
 | `VITE_SUPABASE_URL` | Supabase project URL for the client |
 | `VITE_SUPABASE_ANON_KEY` | Public anon key for browser requests |
 | `OPENAI_API_KEY` | Server key for OpenAI requests |
+| `OPENAI_IMAGE_MODEL` | DALL·E model used by `generate-image` (default `dall-e-3`) |
 | `ENABLE_METRICS` | When set, log latency to `edge_logs` table |
 | `SUPABASE_URL` | Supabase URL for edge functions |
 | `SUPABASE_SERVICE_ROLE_KEY` | Service role key for edge inserts |

--- a/docs/openai_api.md
+++ b/docs/openai_api.md
@@ -7,6 +7,7 @@ Key points:
 - Requests are sent to `https://api.openai.com/v1/chat/completions` with `stream: true`.
 - Chat messages are provided as the `messages` array.
 - After the stream finishes the full assistant text is stored in the `chat_messages` table.
+- Image generation calls `https://api.openai.com/v1/images/generations` using the `OPENAI_IMAGE_MODEL` env var (default `dall-e-3`).
 
 For implementation examples, see the Supabase Edge Functions in [`supabase/functions`](../supabase/functions).
 

--- a/supabase/functions/generate-image/index.ts
+++ b/supabase/functions/generate-image/index.ts
@@ -36,6 +36,8 @@ serve(async (req) => {
     return errorResponse(400, "Missing prompt");
   }
 
+  const model = Deno.env.get("OPENAI_IMAGE_MODEL") || "dall-e-3";
+
   const openaiResp = await fetch(
     "https://api.openai.com/v1/images/generations",
     {
@@ -45,7 +47,7 @@ serve(async (req) => {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        model: "gpt-image-1",
+        model,
         prompt,
       }),
     },


### PR DESCRIPTION
## Summary
- update `generate-image` edge function to use `OPENAI_IMAGE_MODEL`
- document the image model environment variable
- mention image generation usage in OpenAI API docs

## Testing
- `bun run test` *(fails: vitest not installed)*