### PR TITLE
feat(db): allow parents to read their children profiles

### DIFF
--- a/supabase/migrations/202505260035_parent_read_children.sql
+++ b/supabase/migrations/202505260035_parent_read_children.sql
@@ -1,0 +1,10 @@
+alter table profiles enable row level security;
+
+create policy "Parents can read their children profiles"
+on profiles
+for select
+to authenticated
+using (
+  user_role = 'child'
+  and parent_id = auth.uid()
+);


### PR DESCRIPTION
## Summary
- add a migration that enables RLS on `profiles`
- grant parents read access to their children

## Testing
- `bun install`
- `bun run test` *(fails: vitest not found)*