### PR TITLE
Fix migrations for Postgres 14

### DIFF
--- a/supabase/migrations/20250519160000_add_parent_access_to_child_profiles.sql
+++ b/supabase/migrations/20250519160000_add_parent_access_to_child_profiles.sql
@@ -1,13 +1,16 @@
-CREATE POLICY IF NOT EXISTS "Parents can read their children profiles"
+DROP POLICY IF EXISTS "Parents can read their children profiles" ON public.profiles;
+CREATE POLICY "Parents can read their children profiles"
   ON public.profiles FOR SELECT TO authenticated
   USING (parent_id = auth.uid());
 
-CREATE POLICY IF NOT EXISTS "Users can update their own profile"
+DROP POLICY IF EXISTS "Users can update their own profile" ON public.profiles;
+CREATE POLICY "Users can update their own profile"
   ON public.profiles FOR UPDATE TO authenticated
   USING (id = auth.uid())
   WITH CHECK (id = auth.uid());
 
-CREATE POLICY IF NOT EXISTS "Parents can update their children profiles"
+DROP POLICY IF EXISTS "Parents can update their children profiles" ON public.profiles;
+CREATE POLICY "Parents can update their children profiles"
   ON public.profiles FOR UPDATE TO authenticated
   USING (parent_id = auth.uid())
   WITH CHECK (parent_id = auth.uid());

--- a/supabase/migrations/20250519161000_add_parent_access_to_child_chat_history.sql
+++ b/supabase/migrations/20250519161000_add_parent_access_to_child_chat_history.sql
@@ -1,4 +1,5 @@
-CREATE POLICY IF NOT EXISTS "Parents can read their children sessions"
+DROP POLICY IF EXISTS "Parents can read their children sessions" ON public.chat_sessions;
+CREATE POLICY "Parents can read their children sessions"
   ON public.chat_sessions FOR SELECT TO authenticated
   USING (
     user_id IN (
@@ -6,7 +7,8 @@ CREATE POLICY IF NOT EXISTS "Parents can read their children sessions"
     )
   );
 
-CREATE POLICY IF NOT EXISTS "Parents can read their children messages"
+DROP POLICY IF EXISTS "Parents can read their children messages" ON public.chat_messages;
+CREATE POLICY "Parents can read their children messages"
   ON public.chat_messages FOR SELECT TO authenticated
   USING (
     session_id IN (

--- a/supabase/migrations/20250520120000_create_edge_logs.sql
+++ b/supabase/migrations/20250520120000_create_edge_logs.sql
@@ -1,5 +1,7 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 CREATE TABLE IF NOT EXISTS public.edge_logs (
-  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   payload jsonb,
   created_at timestamptz DEFAULT now()
 );

--- a/supabase/migrations/20250521120000_add_update_policy_chat_sessions.sql
+++ b/supabase/migrations/20250521120000_add_update_policy_chat_sessions.sql
@@ -1,4 +1,5 @@
-CREATE POLICY IF NOT EXISTS "Users can update their own sessions"
+DROP POLICY IF EXISTS "Users can update their own sessions" ON public.chat_sessions;
+CREATE POLICY "Users can update their own sessions"
   ON public.chat_sessions FOR UPDATE TO authenticated
   USING (user_id = auth.uid())
   WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- update failing CREATE POLICY calls for Postgres 14
- make `edge_logs` table use `gen_random_uuid()` and ensure pgcrypto

## Testing
- `bun run test` *(fails: vitest not installed)*