### PR TITLE
Add RLS and CI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [View architecture diagram](docs/architecture.md)
 
-## Quick Start
+## Local development
 
 ```bash
 bun install
@@ -21,6 +21,14 @@ Deploy Supabase edge function:
 ```bash
 supabase functions deploy chat --project-ref <project-id>
 ```
+
+## Database & RLS
+
+Row level security ensures adults can read their kids' data while each child only sees their own rows. The policies live in [supabase/migrations](supabase/migrations). See [supabase/migrations/202505260035_parent_read_children.sql](supabase/migrations/202505260035_parent_read_children.sql) for the two policies added on 2025-05-26.
+
+Do **not** use `CREATE POLICY ... IF NOT EXISTS` until Postgres 16. Instead use `DROP POLICY IF EXISTS ...; CREATE POLICY ...`.
+
+When adding columns, wrap the `ALTER TABLE` in an existence check as shown in [supabase/migrations/20250521133000_add_hidden.sql](supabase/migrations/20250521133000_add_hidden.sql).
 
 ## Environment Variables
 

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -1,0 +1,20 @@
+# CI Workflows
+
+This repository uses GitHub Actions to deploy and verify the database.
+
+## Workflows overview
+
+- **run-migrations.yml** – pushes Supabase migrations using the CLI.
+- **parent-child-access-test.yml** – logs in as the demo adult user and fails if that user cannot read child rows.
+
+## Adding new secrets
+
+1. Open the repository on GitHub.
+2. Navigate to **Settings → Secrets → Actions**.
+3. Click **New repository secret** and provide the name and value.
+
+## Exit codes
+
+- `0` – workflow step succeeded.
+- `1` – general failure (e.g. migration error or login failure).
+- `2` – parent-child access test ran but found no rows (RLS blocked the parent).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -37,3 +37,12 @@ Use the Supabase CLI:
 ```bash
 supabase functions deploy chat --project-ref <project-id>
 ```
+
+## Writing Migrations
+
+- Generate a new migration with `supabase migration new <name>`; the CLI prefixes the file with a timestamp so order is preserved.
+- Make migrations re-runnable:
+  - `DROP POLICY IF EXISTS ...; CREATE POLICY ...` for policy changes.
+  - Wrap `ALTER TABLE ... ADD COLUMN` in an existence check as seen in [`../supabase/migrations/20250521133000_add_hidden.sql`](../supabase/migrations/20250521133000_add_hidden.sql).
+- Whenever `package.json` changes, run `bun install` and commit the updated `bun.lockb`.
+- CI runs `bun install --frozen-lockfile`; forgetting to commit `bun.lockb` will break builds.


### PR DESCRIPTION
## Summary
- rename Quick Start -> Local development in README
- document new RLS policies and idempotent migration tips
- add `docs/ci-workflows.md` describing GitHub Actions
- extend contributing guide with migration tips and lockfile notes

## Testing
- `bun run test` *(fails: vitest not found)*