### PR TITLE
feat(ui): sort chat sessions and show date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## [Unreleased]
 - _Add new entries here for each `feat:` PR._
 
+### Added
+- Sessions list displays most recent chats first with last interaction date.
+
 ### Fixed
 - Resolve Netlify 404 when navigating directly to `/login`.
 

--- a/src/components/ChatSessionRow.tsx
+++ b/src/components/ChatSessionRow.tsx
@@ -5,7 +5,7 @@ import { invokeWithAuth } from "@/lib/invokeWithAuth";
 import { useChat } from "@/contexts/ChatContext";
 
 interface Props {
-  session: { id: string; title: string };
+  session: { id: string; title: string; lastUpdated?: number | null };
   onSelect: (id: string) => void;
 }
 
@@ -57,7 +57,14 @@ export default function ChatSessionRow({ session, onSelect }: Props) {
       onClick={() => onSelect(session.id)}
       onTouchStart={toggle}
     >
-      <span className="truncate">{session.title}</span>
+      <div className="flex flex-col flex-1 overflow-hidden">
+        <span className="truncate font-bold">{session.title}</span>
+        {session.lastUpdated && (
+          <span className="text-xs text-muted-foreground">
+            {new Date(session.lastUpdated).toLocaleDateString()}
+          </span>
+        )}
+      </div>
 
       <div
         className={`absolute right-1 top-1 flex gap-2 transition-opacity duration-200 pointer-events-none opacity-0 group-hover:opacity-100 focus-within:opacity-100 ${show ? "opacity-100 pointer-events-auto" : ""}`}

--- a/src/components/settings/ChatHistory.tsx
+++ b/src/components/settings/ChatHistory.tsx
@@ -38,7 +38,15 @@ const ChatHistory: React.FC = () => {
   return (
     <ul className="space-y-1">
       {chatSessions.map((session) => (
-        <ChatSessionRow key={session.id} session={{ id: session.id, title: session.name || "New chat" }} onSelect={switchToChat} />
+        <ChatSessionRow
+          key={session.id}
+          session={{
+            id: session.id,
+            title: session.name || "New chat",
+            lastUpdated: session.lastUpdated,
+          }}
+          onSelect={switchToChat}
+        />
       ))}
     </ul>
   );

--- a/src/hooks/chatSessions/useActiveSession.ts
+++ b/src/hooks/chatSessions/useActiveSession.ts
@@ -8,7 +8,10 @@ export const useActiveSession = (chatSessions: ChatSession[]) => {
   
   // Get visible chat sessions (not hidden)
   const visibleSessions = useMemo(() => {
-    return chatSessions.filter(session => !hiddenSessionIds.includes(session.id));
+    return chatSessions
+      .filter(session => !hiddenSessionIds.includes(session.id))
+      .slice()
+      .sort((a, b) => (b.lastUpdated ?? 0) - (a.lastUpdated ?? 0));
   }, [chatSessions, hiddenSessionIds]);
   
   // Find the active chat session


### PR DESCRIPTION
### What & Why
- display sessions in reverse chronological order
- bold session names and show last interaction date

### How Tested
```bash
bun run lint && bun run test
```
