### PR TITLE
feat: automatic session summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Added
 - Sessions list displays most recent chats first with last interaction date.
 - CI-generated Mermaid component map for React hierarchy.
+- Automatic session summaries via GPT
 
 ### Fixed
 - Resolve Netlify 404 when navigating directly to `/login`.

--- a/docs/supabase.md
+++ b/docs/supabase.md
@@ -9,3 +9,5 @@ Edge functions handle chat streaming and image generation. Deploy them with:
 ```bash
 supabase functions deploy <name> --project-ref <id>
 ```
+The `chat_sessions` table now includes a `session_summary` column used to store a model-generated recap of each conversation.
+

--- a/src/hooks/chatSessions/useChatDatabase.ts
+++ b/src/hooks/chatSessions/useChatDatabase.ts
@@ -21,7 +21,7 @@ export const useChatDatabase = () => {
       // Fetch all chat sessions for the current user
       const { data, error } = await supabase
         .from("chat_sessions")
-        .select("id, name, last_updated")
+        .select("id, name, last_updated, session_summary")
         .eq("user_id", userId)
         .order("last_updated", { ascending: false });
 
@@ -54,6 +54,7 @@ export const useChatDatabase = () => {
               name: session.name,
               messages: messages,
               lastUpdated: new Date(session.last_updated).getTime(),
+              sessionSummary: session.session_summary,
             };
           }),
         );
@@ -120,6 +121,7 @@ export const useChatDatabase = () => {
         name: null,
         messages: [messageWithId],
         lastUpdated: timestamp,
+        sessionSummary: '',
       };
 
       console.log("Created new chat session:", newSession);

--- a/src/hooks/useChatNameGenerator.ts
+++ b/src/hooks/useChatNameGenerator.ts
@@ -32,7 +32,7 @@ export const useChatNameGenerator = (
       count !== lastGeneratedCountRef.current
     ) {
       lastGeneratedCountRef.current = count;
-      generateChatName(messages).then(name => {
+      generateChatName(activeChatId, messages).then(name => {
         updateChatName(activeChatId, name);
       });
     }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -53,6 +53,7 @@ export type Database = {
           is_hidden: boolean
           last_updated: string
           name: string | null
+          session_summary: string
           user_id: string
         }
         Insert: {
@@ -60,6 +61,7 @@ export type Database = {
           is_hidden?: boolean
           last_updated?: string
           name?: string | null
+          session_summary?: string
           user_id: string
         }
         Update: {
@@ -67,6 +69,7 @@ export type Database = {
           is_hidden?: boolean
           last_updated?: string
           name?: string | null
+          session_summary?: string
           user_id?: string
         }
         Relationships: []

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -12,4 +12,5 @@ export interface ChatSession {
   name: string | null;
   messages: Message[];
   lastUpdated: number | null;
+  sessionSummary?: string;
 }

--- a/src/types/chatContext.ts
+++ b/src/types/chatContext.ts
@@ -5,6 +5,7 @@ export interface ChatSession {
   name: string | null;
   messages: Message[];
   lastUpdated: number | null;
+  sessionSummary?: string;
 }
 
 export interface ChatContextType {

--- a/src/utils/chatNameGenerator.ts
+++ b/src/utils/chatNameGenerator.ts
@@ -2,7 +2,10 @@
 import { Message } from '@/types/chat';
 import { invokeWithAuth } from '@/lib/invokeWithAuth';
 
-export const generateChatName = async (messages: Message[]): Promise<string> => {
+export const generateChatName = async (
+  sessionId: string,
+  messages: Message[],
+): Promise<string> => {
   try {
     // Format messages for the API
     const chatHistory = messages.map(msg => ({
@@ -18,6 +21,7 @@ export const generateChatName = async (messages: Message[]): Promise<string> => 
     
     // Call the Supabase edge function to generate a title
     const { data, error } = await invokeWithAuth('generate-chat-name', {
+      session_id: sessionId,
       messages: chatHistory,
       model: 'gpt-4.1-nano'
     });

--- a/supabase/migrations/20250526160000_add_session_summary.sql
+++ b/supabase/migrations/20250526160000_add_session_summary.sql
@@ -1,0 +1,13 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'chat_sessions'
+        AND column_name = 'session_summary'
+  ) THEN
+    ALTER TABLE public.chat_sessions
+      ADD COLUMN session_summary text NOT NULL DEFAULT '';
+    COMMENT ON COLUMN public.chat_sessions.session_summary IS 'Model-generated recap (requested ≤140 chars; actual length may vary).';
+  END IF;
+END $$;


### PR DESCRIPTION
### What & Why
- add `session_summary` column
- update edge function to request ≤140-char recap via gpt-4.1-nano
- regenerate supabase types

### How Tested
```bash
bun run lint && bun run test
```
