### PR TITLE
Add parent child view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Sessions list displays most recent chats first with last interaction date.
 - CI-generated Mermaid component map for React hierarchy.
 - Automatic session summaries via GPT
+- Parent-only child view for editing profiles and browsing sessions.
 
 ### Fixed
 - Resolve Netlify 404 when navigating directly to `/login`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import NotFound from "./pages/NotFound";
 import Profile from "./pages/Profile";
 import Login from "./pages/Login";
 import ChildHistory from "./pages/ChildHistory";
+import ChildView from "./pages/ChildView";
 import AuthGuard from "./components/auth/AuthGuard";
 
 const queryClient = new QueryClient();
@@ -44,6 +45,14 @@ const App = () => (
                 element={
                   <AuthGuard>
                     <ChildHistory />
+                  </AuthGuard>
+                }
+              />
+              <Route
+                path="/children/:childId"
+                element={
+                  <AuthGuard>
+                    <ChildView />
                   </AuthGuard>
                 }
               />

--- a/src/components/common/SessionListItem.tsx
+++ b/src/components/common/SessionListItem.tsx
@@ -1,0 +1,22 @@
+import { format } from 'date-fns';
+
+interface Props {
+  session: { id: string; name: string | null; description: string | null; lastUpdated: string };
+  onSelect: (id: string) => void;
+}
+
+export default function SessionListItem({ session, onSelect }: Props) {
+  return (
+    <li
+      className="px-3 py-2 rounded-md cursor-pointer hover:bg-muted"
+      onClick={() => onSelect(session.id)}
+    >
+      <div className="flex flex-col overflow-hidden">
+        <span className="truncate font-medium">{session.name || 'New chat'}</span>
+        <span className="text-xs text-muted-foreground truncate">
+          {session.description || ''} · {format(new Date(session.lastUpdated), 'yyyy-MM-dd')}
+        </span>
+      </div>
+    </li>
+  );
+}

--- a/src/components/common/__tests__/SessionListItem.test.tsx
+++ b/src/components/common/__tests__/SessionListItem.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import SessionListItem from '../SessionListItem';
+
+// basic server-side render test without jsdom
+
+describe('SessionListItem', () => {
+  it('renders title text', () => {
+    const html = renderToString(
+      <ul>
+        <SessionListItem session={{ id: '1', name: 'chat', description: 'hello', lastUpdated: '2024-01-01T00:00:00Z' }} onSelect={vi.fn()} />
+      </ul>
+    );
+    expect(html).toContain('chat');
+    expect(html).toContain('hello');
+  });
+});

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,0 +1,1 @@
+export { default as SessionListItem } from './SessionListItem';

--- a/src/components/profile/ChildAccountsSection.tsx
+++ b/src/components/profile/ChildAccountsSection.tsx
@@ -126,7 +126,7 @@ const ChildAccountsSection: React.FC = () => {
               </p>
             )}
             <Link
-              to={`/child-history/${child.id}`}
+              to={`/children/${child.id}`}
               className="text-xs text-blue-600 hover:underline"
             >
               View history

--- a/src/hooks/chatSessions/useChatDatabase.ts
+++ b/src/hooks/chatSessions/useChatDatabase.ts
@@ -21,7 +21,7 @@ export const useChatDatabase = () => {
       // Fetch all chat sessions for the current user
       const { data, error } = await supabase
         .from("chat_sessions")
-        .select("id, name, last_updated, session_summary")
+        .select("id, name, last_updated, session_summary, description")
         .eq("user_id", userId)
         .order("last_updated", { ascending: false });
 
@@ -55,6 +55,7 @@ export const useChatDatabase = () => {
               messages: messages,
               lastUpdated: new Date(session.last_updated).getTime(),
               sessionSummary: session.session_summary,
+              description: session.description,
             };
           }),
         );
@@ -122,6 +123,7 @@ export const useChatDatabase = () => {
         messages: [messageWithId],
         lastUpdated: timestamp,
         sessionSummary: '',
+        description: null,
       };
 
       console.log("Created new chat session:", newSession);

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -54,6 +54,7 @@ export type Database = {
           last_updated: string
           name: string | null
           session_summary: string
+          description: string | null
           user_id: string
         }
         Insert: {
@@ -62,6 +63,7 @@ export type Database = {
           last_updated?: string
           name?: string | null
           session_summary?: string
+          description?: string | null
           user_id: string
         }
         Update: {
@@ -70,6 +72,7 @@ export type Database = {
           last_updated?: string
           name?: string | null
           session_summary?: string
+          description?: string | null
           user_id?: string
         }
         Relationships: []

--- a/src/pages/ChildView.tsx
+++ b/src/pages/ChildView.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/lib/supa';
+import { Button } from '@/components/ui/button';
+import EditableField from '@/components/profile/EditableField';
+import { SessionListItem } from '@/components/common';
+import { ArrowLeft } from 'lucide-react';
+
+interface SessionRow { id: string; name: string | null; description: string | null; last_updated: string; }
+
+const fetchChild = async (childId: string) => {
+  const { data, error } = await supabase.functions.invoke(`children/${childId}`, { method: 'GET' });
+  if (error) throw new Error(error.message);
+  return data as { profile: { display_name: string | null; system_message: string | null }; sessions: SessionRow[] };
+};
+
+const ChildView: React.FC = () => {
+  const { childId } = useParams<{ childId: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery(['child', childId], () => fetchChild(childId!), { enabled: !!childId });
+
+  const [name, setName] = useState('');
+  const [prompt, setPrompt] = useState('');
+
+  React.useEffect(() => {
+    if (data) {
+      setName(data.profile.display_name || '');
+      setPrompt(data.profile.system_message || '');
+    }
+  }, [data]);
+
+  const saveMutation = useMutation(
+    async () => {
+      await supabase.functions.invoke(`children/${childId}`, {
+        method: 'PATCH',
+        body: { display_name: name, system_message: prompt }
+      });
+    },
+    { onSuccess: () => queryClient.invalidateQueries(['child', childId]) }
+  );
+
+  if (!childId) return <p className="p-4">Child not found.</p>;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="fixed top-0 w-full bg-white border-b border-gray-100 h-14 flex items-center px-4 z-10">
+        <Button variant="ghost" size="icon" onClick={() => navigate('/profile')}>
+          <ArrowLeft />
+          <span className="sr-only">Back</span>
+        </Button>
+        <h1 className="flex-1 text-center font-medium">Child View</h1>
+      </header>
+      <main className="pt-16 p-4 max-w-md mx-auto space-y-6">
+        {isLoading || !data ? (
+          <p>Loading...</p>
+        ) : (
+          <>
+            <div className="space-y-2">
+              <EditableField value={name} onChange={setName} onSave={() => saveMutation.mutate()} />
+              <EditableField
+                value={prompt}
+                onChange={setPrompt}
+                onSave={() => saveMutation.mutate()}
+                inputClassName="w-full border-gray-300"
+                className="text-sm text-muted-foreground"
+              />
+            </div>
+            <div className="space-y-2">
+              <h2 className="font-medium">Chat Sessions</h2>
+              <ul className="space-y-1">
+                {data.sessions.map((s) => (
+                  <SessionListItem
+                    key={s.id}
+                    session={{
+                      id: s.id,
+                      name: s.name,
+                      description: s.description,
+                      lastUpdated: s.last_updated
+                    }}
+                    onSelect={(id) => navigate(`/sessions/${id}`)}
+                  />
+                ))}
+              </ul>
+            </div>
+          </>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default ChildView;

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -13,4 +13,5 @@ export interface ChatSession {
   messages: Message[];
   lastUpdated: number | null;
   sessionSummary?: string;
+  description?: string | null;
 }

--- a/src/types/chatContext.ts
+++ b/src/types/chatContext.ts
@@ -6,6 +6,7 @@ export interface ChatSession {
   messages: Message[];
   lastUpdated: number | null;
   sessionSummary?: string;
+  description?: string | null;
 }
 
 export interface ChatContextType {

--- a/supabase/functions/children/index.ts
+++ b/supabase/functions/children/index.ts
@@ -1,0 +1,68 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { corsHeaders } from '../_shared/cors.ts';
+
+function jsonResponse(payload: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+  });
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const url = new URL(req.url);
+  const segments = url.pathname.split('/');
+  const childId = segments[segments.length - 1] || '';
+  if (!childId) {
+    return jsonResponse({ error: 'child_id required' }, 400);
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+  const anon = Deno.env.get('SUPABASE_ANON_KEY')!;
+  const jwt = req.headers.get('authorization')?.replace('Bearer ', '') ?? '';
+
+  const supabase = createClient(supabaseUrl, anon, {
+    global: { headers: { authorization: `Bearer ${jwt}` } }
+  });
+
+  if (req.method === 'GET') {
+    const { data: profile, error: profErr } = await supabase
+      .from('profiles')
+      .select('id, display_name, system_message')
+      .eq('id', childId)
+      .maybeSingle();
+    if (profErr) return jsonResponse({ error: profErr.message }, 500);
+
+    const { data: sessions, error: sessErr } = await supabase
+      .from('chat_sessions')
+      .select('id, name, description, last_updated')
+      .eq('user_id', childId)
+      .order('last_updated', { ascending: false });
+    if (sessErr) return jsonResponse({ error: sessErr.message }, 500);
+
+    return jsonResponse({ profile, sessions });
+  }
+
+  if (req.method === 'PATCH') {
+    let body: any = {};
+    try { body = await req.json(); } catch {}
+    const updates: Record<string, unknown> = {};
+    if (typeof body.display_name === 'string') updates.display_name = body.display_name;
+    if (typeof body.system_message === 'string') updates.system_message = body.system_message;
+    if (Object.keys(updates).length === 0) {
+      return jsonResponse({ error: 'No valid fields' }, 400);
+    }
+    const { error } = await supabase
+      .from('profiles')
+      .update(updates)
+      .eq('id', childId);
+    if (error) return jsonResponse({ error: error.message }, 500);
+    return jsonResponse({ success: true });
+  }
+
+  return jsonResponse({ error: 'Method not allowed' }, 405);
+});

--- a/supabase/migrations/20250531100000_add_description_to_chat_sessions.sql
+++ b/supabase/migrations/20250531100000_add_description_to_chat_sessions.sql
@@ -1,0 +1,30 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name   = 'chat_sessions'
+        AND column_name  = 'description'
+  ) THEN
+    ALTER TABLE public.chat_sessions
+      ADD COLUMN description text;
+    COMMENT ON COLUMN public.chat_sessions.description IS '140-char recap, copied from session_summary when present';
+  END IF;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.sync_chat_description()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.description IS NULL AND NEW.session_summary IS NOT NULL THEN
+    NEW.description := left(trim(NEW.session_summary), 140);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sync_chat_description ON public.chat_sessions;
+CREATE TRIGGER trg_sync_chat_description
+BEFORE INSERT OR UPDATE ON public.chat_sessions
+FOR EACH ROW EXECUTE PROCEDURE public.sync_chat_description();

--- a/supabase/migrations/20250531101000_parent_update_child_chat.sql
+++ b/supabase/migrations/20250531101000_parent_update_child_chat.sql
@@ -1,0 +1,32 @@
+-- Allow parents to update child sessions and messages
+DROP POLICY IF EXISTS "Parents can update their children sessions" ON public.chat_sessions;
+CREATE POLICY "Parents can update their children sessions"
+  ON public.chat_sessions FOR UPDATE TO authenticated
+  USING (
+    user_id IN (
+      SELECT id FROM public.profiles WHERE parent_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    user_id IN (
+      SELECT id FROM public.profiles WHERE parent_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Parents can update their children messages" ON public.chat_messages;
+CREATE POLICY "Parents can update their children messages"
+  ON public.chat_messages FOR UPDATE TO authenticated
+  USING (
+    session_id IN (
+      SELECT id FROM public.chat_sessions WHERE user_id IN (
+        SELECT id FROM public.profiles WHERE parent_id = auth.uid()
+      )
+    )
+  )
+  WITH CHECK (
+    session_id IN (
+      SELECT id FROM public.chat_sessions WHERE user_id IN (
+        SELECT id FROM public.profiles WHERE parent_id = auth.uid()
+      )
+    )
+  );


### PR DESCRIPTION
### What & Why
- add `description` column and trigger for chat_sessions
- allow parents to update child sessions/messages via RLS
- expose new `children/:child_id` edge function
- create `/children/:childId` page with editable fields and session list

### How Tested
```bash
bun run lint && bun run test
```

Checklist
- [x] Tests pass & lint clean
- [x] RLS policies respected
- [ ] Edge function deployed (if applicable)
- [x] Documentation updated (CHANGELOG)
