### PR TITLE
Fix Run Supabase Migrations workflow

### DIFF
--- a/.github/workflows/run-migrations.yml
+++ b/.github/workflows/run-migrations.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Apply migrations
         run: supabase db push
 
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
       - name: Ensure storage bucket exists
         env:
           IMAGE_BUCKET: ${{ secrets.IMAGE_BUCKET }}


### PR DESCRIPTION
### What & Why
- install Bun before executing `bunx` in migrations workflow so bucket creation step succeeds

### How Tested
```bash
bun run lint
bun run test
```
All tests pass.

Checklist
- [x] Tests pass & lint clean
- [ ] RLS policies respected
- [ ] Edge function deployed (if applicable)
- [ ] Documentation updated (README / docs/)