### PR TITLE
Fix Run Supabase Migrations workflow

### DIFF
--- a/.github/workflows/run-migrations.yml
+++ b/.github/workflows/run-migrations.yml
@@ -34,6 +34,13 @@ jobs:
       - name: Apply migrations
         run: supabase db push
 
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Ensure storage bucket exists
         env:
           IMAGE_BUCKET: ${{ secrets.IMAGE_BUCKET }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+pnpm-lock.yaml


### PR DESCRIPTION
### What & Why
- remove stray `pnpm-lock.yaml`
- install Bun dependencies before running storage bucket script in migrations workflow

### How Tested
```bash
bun run lint && bun run test
```
All tests pass.

Checklist
- [x] Tests pass & lint clean
- [ ] RLS policies respected
- [ ] Edge function deployed (if applicable)
- [ ] Documentation updated (README / docs/)
