### PR TITLE
feat(summary): store and display session summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Sessions list displays most recent chats first with last interaction date.
 - CI-generated Mermaid component map for React hierarchy.
 - Automatic session summaries via GPT
+- Session summary stored in DB and shown to parents
 
 ### Fixed
 - Resolve Netlify 404 when navigating directly to `/login`.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -8,5 +8,8 @@ Metadata is written server-side using the service role key so that row level sec
 not block updates. The function updates `chat_sessions.name` and `chat_sessions.session_summary`
 directly and returns the values only for debugging.
 
+As of May 2025 the summary field is truncated to 200 characters before saving.
+The UI displays this recap for adult accounts only.
+
 To keep API costs low the request payloads are short and generation runs at most once every
 three assistant messages.

--- a/src/components/ChatSessionRow.tsx
+++ b/src/components/ChatSessionRow.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
+import { useFeatureAccess } from "@/hooks/useFeatureAccess";
 import { EyeOff, Trash2 } from "lucide-react";
 import { toast } from "@/components/ui/use-toast";
 import { invokeWithAuth } from "@/lib/invokeWithAuth";
 import { useChat } from "@/contexts/ChatContext";
 
 interface Props {
-  session: { id: string; title: string; lastUpdated?: number | null };
+  session: { id: string; title: string; lastUpdated?: number | null; sessionSummary?: string };
   onSelect: (id: string) => void;
 }
 
@@ -15,6 +16,7 @@ export default function ChatSessionRow({ session, onSelect }: Props) {
   const [deleting, setDeleting] = useState(false);
   const toggle = () => setShow((v) => !v);
   const { hideSession, removeSessionLocal } = useChat();
+  const { isAdult } = useFeatureAccess();
 
   const hide = async () => {
     setHiding(true);
@@ -62,6 +64,11 @@ export default function ChatSessionRow({ session, onSelect }: Props) {
         {session.lastUpdated && (
           <span className="text-xs text-muted-foreground">
             {new Date(session.lastUpdated).toLocaleDateString()}
+          </span>
+        )}
+        {isAdult && session.sessionSummary && (
+          <span className="text-xs text-muted-foreground truncate">
+            {session.sessionSummary}
           </span>
         )}
       </div>

--- a/src/components/profile/ChildChatHistory.tsx
+++ b/src/components/profile/ChildChatHistory.tsx
@@ -46,7 +46,14 @@ const ChildChatHistory: React.FC<ChildChatHistoryProps> = ({ childId }) => {
       {sessions.map((session) => (
         <AccordionItem key={session.id} value={session.id}>
           <AccordionTrigger>
-            {session.name || 'Unnamed chat'}
+            <div className="flex flex-col text-left">
+              <span>{session.name || 'Unnamed chat'}</span>
+              {session.sessionSummary && (
+                <span className="text-xs text-muted-foreground truncate">
+                  {session.sessionSummary}
+                </span>
+              )}
+            </div>
           </AccordionTrigger>
           <AccordionContent>
             <MessageList messages={session.messages} />

--- a/src/components/settings/ChatHistory.tsx
+++ b/src/components/settings/ChatHistory.tsx
@@ -44,6 +44,7 @@ const ChatHistory: React.FC = () => {
             id: session.id,
             title: session.name || "New chat",
             lastUpdated: session.lastUpdated,
+            sessionSummary: session.sessionSummary,
           }}
           onSelect={switchToChat}
         />

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -73,6 +73,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({
     createNewChat: createNewChatSession,
     switchToChat: switchToChatSession,
     updateChatName,
+    stashSessionSummary,
     updateSessionMessages,
     hideSession,
     unhideSession,
@@ -125,6 +126,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({
     activeSession.name,
     activeChatId,
     updateChatName,
+    stashSessionSummary,
     isWaitingForResponse,
   );
 
@@ -398,6 +400,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({
         createNewChat,
         switchToChat,
         updateChatName,
+        stashSessionSummary,
         hideSession,
         unhideSession,
         deleteSession,

--- a/src/hooks/chatSessions/useChatSessions.ts
+++ b/src/hooks/chatSessions/useChatSessions.ts
@@ -26,7 +26,7 @@ export const useChatSessions = (initialMessages: Message[] = []) => {
     visibleSessions,
   } = useActiveSession(chatSessions);
 
-  const { createNewChat, switchToChat, updateChatName, deleteChat } =
+  const { createNewChat, switchToChat, updateChatName, deleteChat, stashSessionSummary } =
     useSessionManagement(
       chatSessions,
       setChatSessions,
@@ -183,6 +183,7 @@ export const useChatSessions = (initialMessages: Message[] = []) => {
     createNewChat,
     switchToChat,
     updateChatName,
+    stashSessionSummary,
     deleteChat,
     updateSessionMessages,
     hiddenSessionIds,

--- a/src/hooks/chatSessions/useSessionManagement.ts
+++ b/src/hooks/chatSessions/useSessionManagement.ts
@@ -104,6 +104,17 @@ export const useSessionManagement = (
     [user, updateChatNameInDb, setChatSessions],
   );
 
+  const stashSessionSummary = useCallback(
+    (id: string, summary: string) => {
+      setChatSessions(prev =>
+        prev.map(session =>
+          session.id === id ? { ...session, sessionSummary: summary } : session,
+        ),
+      );
+    },
+    [setChatSessions],
+  );
+
   // Delete a chat session
   const deleteChat = useCallback(
     async (id: string) => {
@@ -159,6 +170,7 @@ export const useSessionManagement = (
     createNewChat,
     switchToChat,
     updateChatName,
+    stashSessionSummary,
     deleteChat,
   };
 };

--- a/src/hooks/useChatNameGenerator.ts
+++ b/src/hooks/useChatNameGenerator.ts
@@ -9,6 +9,7 @@ export const useChatNameGenerator = (
   chatName: string | null,
   activeChatId: string,
   updateChatName: (id: string, name: string) => void,
+  stashSummary: (id: string, summary: string) => void,
   isWaitingForResponse: boolean
 ) => {
   const lastGeneratedCountRef = useRef(0);
@@ -30,9 +31,10 @@ export const useChatNameGenerator = (
       count !== lastGeneratedCountRef.current
     ) {
       lastGeneratedCountRef.current = count;
-      generateChatName(activeChatId, messages)
-        .then((name) => {
-          updateChatName(activeChatId, name);
+      generateChatName(activeChatId)
+        .then(({ title, sessionSummary }) => {
+          updateChatName(activeChatId, title);
+          stashSummary(activeChatId, sessionSummary);
         })
         .catch((err) => {
           console.error('generateChatName failed', err);

--- a/src/types/chatContext.ts
+++ b/src/types/chatContext.ts
@@ -23,6 +23,7 @@ export interface ChatContextType {
   createNewChat: () => void;
   switchToChat: (id: string) => void;
   updateChatName: (id: string, newName: string) => void;
+  stashSessionSummary: (id: string, summary: string) => void;
   hideSession: (id: string) => void;
   unhideSession: (id: string) => void;
   deleteSession: (id: string) => void;

--- a/src/utils/chatNameGenerator.ts
+++ b/src/utils/chatNameGenerator.ts
@@ -1,28 +1,12 @@
 
-import { Message } from '@/types/chat';
 import { invokeWithAuth } from '@/lib/invokeWithAuth';
 
 export const generateChatName = async (
   sessionId: string,
-  messages: Message[],
-): Promise<string> => {
+): Promise<{ title: string; sessionSummary: string }> => {
   try {
-    // Format messages for the API
-    const chatHistory = messages.map(msg => ({
-      role: msg.isUser ? 'user' : 'assistant',
-      content: msg.content
-    }));
-    
-    // Add a specific request to generate a short, descriptive title
-    chatHistory.push({
-      role: 'user',
-      content: 'Based on our conversation so far, generate a very short, descriptive title (3-5 words max) that captures the essence of this chat. Respond with just the title, no additional text or explanation.'
-    });
-    
-    // Call the Supabase edge function to generate a title
     const { data, error } = await invokeWithAuth('generate-chat-name', {
       session_id: sessionId,
-      messages: chatHistory,
     });
 
     if (error) {
@@ -30,13 +14,15 @@ export const generateChatName = async (
     }
     
     if (data && data.title) {
-      return data.title.trim();
+      return {
+        title: data.title.trim(),
+        sessionSummary: data.session_summary ?? '',
+      };
     }
 
-    return 'Chat Session'; // Default fallback
+    return { title: 'Chat Session', sessionSummary: '' };
   } catch (error) {
     console.error('Error generating chat name:', error);
-    // Fallback to a default name if there's an error
-    return 'Chat Session';
+    return { title: 'Chat Session', sessionSummary: '' };
   }
 };

--- a/supabase/functions/generate-chat-name/index.ts
+++ b/supabase/functions/generate-chat-name/index.ts
@@ -52,7 +52,7 @@ serve(async (req) => {
 
     const supabaseUrl = Deno.env.get("SUPABASE_URL");
     const serviceRole = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-    const supabase = supabaseUrl && serviceRole
+    const supabaseAdmin = supabaseUrl && serviceRole
       ? createClient(supabaseUrl, serviceRole)
       : null;
 
@@ -136,8 +136,8 @@ serve(async (req) => {
           .join("")
       : data.output_text;
     let sessionSummary = "";
-    if (supabase) {
-      const { data: history, error: histErr } = await supabase
+    if (supabaseAdmin) {
+      const { data: history, error: histErr } = await supabaseAdmin
         .from("chat_messages")
         .select("content, is_user")
         .eq("session_id", session_id)
@@ -184,12 +184,12 @@ serve(async (req) => {
       }
     }
 
-    if (supabase) {
-      const { error: updErr } = await supabase
+    if (supabaseAdmin) {
+      const { error: updErr } = await supabaseAdmin
         .from("chat_sessions")
         .update({
           name: title,
-          session_summary: sessionSummary,
+          session_summary: sessionSummary.slice(0, 200),
           updated_at: new Date().toISOString(),
         })
         .eq("id", session_id);

--- a/tests/useChatNameGenerator.test.tsx
+++ b/tests/useChatNameGenerator.test.tsx
@@ -4,7 +4,7 @@ import { useChatNameGenerator } from '@/hooks/useChatNameGenerator';
 import { Message } from '@/types/chat';
 
 vi.mock('@/utils/chatNameGenerator', () => ({
-  generateChatName: vi.fn(() => Promise.resolve('AI Title')),
+  generateChatName: vi.fn(() => Promise.resolve({ title: 'AI Title', sessionSummary: 'summary' })),
 }));
 vi.mock('@/components/ui/use-toast', () => ({
   toast: vi.fn(),
@@ -15,7 +15,7 @@ describe.skip('useChatNameGenerator', () => {
     const update = vi.fn();
     const messages: Message[] = [];
     const { rerender } = renderHook((props: { msgs: Message[] }) =>
-      useChatNameGenerator(props.msgs, null, 's1', update, false)
+      useChatNameGenerator(props.msgs, null, 's1', update, vi.fn(), false)
     , { initialProps: { msgs: messages } });
 
     const push = (content: string, isUser = false) => {


### PR DESCRIPTION
### What & Why
- edge function now stores `session_summary` capped at 200 chars
- frontend helper returns summary and stashes it optimistically
- show summaries for adult users in chat history
- document new behavior

### How Tested
```bash
bun run lint && bun run test
```
