### PR TITLE
feat(profile): add parent child view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - CI-generated Mermaid component map for React hierarchy.
 - Automatic session summaries via GPT
 - Session summary stored in DB and shown to parents
+- Parent-only child view with editable prompt and session list
 
 ### Fixed
 - Resolve Netlify 404 when navigating directly to `/login`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import Profile from "./pages/Profile";
 import Login from "./pages/Login";
-import ChildHistory from "./pages/ChildHistory";
+import ChildView from "./pages/ChildView";
 import AuthGuard from "./components/auth/AuthGuard";
 
 const queryClient = new QueryClient();
@@ -40,10 +40,10 @@ const App = () => (
                 }
               />
               <Route
-                path="/child-history/:childId"
+                path="/children/:childId"
                 element={
                   <AuthGuard>
-                    <ChildHistory />
+                    <ChildView />
                   </AuthGuard>
                 }
               />

--- a/src/components/profile/ChildAccountsSection.tsx
+++ b/src/components/profile/ChildAccountsSection.tsx
@@ -126,7 +126,7 @@ const ChildAccountsSection: React.FC = () => {
               </p>
             )}
             <Link
-              to={`/child-history/${child.id}`}
+              to={`/children/${child.id}`}
               className="text-xs text-blue-600 hover:underline"
             >
               View history

--- a/src/lib/fetchWithAuth.test.ts
+++ b/src/lib/fetchWithAuth.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./supa', () => ({
+  supabase: {
+    auth: { getSession: vi.fn() }
+  }
+}));
+
+import { supabase } from './supa';
+import { fetchWithAuth } from './fetchWithAuth';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  globalThis.fetch = vi.fn() as any;
+});
+
+describe('fetchWithAuth', () => {
+  it('adds bearer token when session exists', async () => {
+    (supabase.auth.getSession as any).mockResolvedValue({ data: { session: { access_token: 't' } } });
+    (globalThis.fetch as any).mockResolvedValue('ok');
+    await fetchWithAuth('/x', { method: 'GET' });
+    const opts = (globalThis.fetch as any).mock.calls[0][1] as RequestInit;
+    expect(opts.headers.get('Authorization')).toBe('Bearer t');
+  });
+
+  it('omits header when no session', async () => {
+    (supabase.auth.getSession as any).mockResolvedValue({ data: { session: null } });
+    (globalThis.fetch as any).mockResolvedValue('ok');
+    await fetchWithAuth('/y');
+    const opts = (globalThis.fetch as any).mock.calls[0][1] as RequestInit;
+    expect((opts.headers as Headers).get('Authorization')).toBeNull();
+  });
+});

--- a/src/lib/fetchWithAuth.ts
+++ b/src/lib/fetchWithAuth.ts
@@ -1,0 +1,9 @@
+import { supabase } from './supa';
+
+export async function fetchWithAuth(url: string, init: RequestInit = {}) {
+  const { data: { session } } = await supabase.auth.getSession();
+  const token = session?.access_token;
+  const headers = new Headers(init.headers as HeadersInit);
+  if (token) headers.set('Authorization', `Bearer ${token}`);
+  return fetch(url, { ...init, headers });
+}

--- a/src/pages/ChildView.tsx
+++ b/src/pages/ChildView.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { fetchChildProfile, updateChildProfile, ChildSession } from '@/utils/childViewApi';
+import EditableField from '@/components/profile/EditableField';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft, Loader2, Trash2 } from 'lucide-react';
+import { useFeatureAccess } from '@/hooks/useFeatureAccess';
+import { invokeWithAuth } from '@/lib/invokeWithAuth';
+
+const ChildView: React.FC = () => {
+  const { childId } = useParams<{ childId: string }>();
+  const navigate = useNavigate();
+  const { isAdult } = useFeatureAccess();
+  const [loading, setLoading] = useState(true);
+  const [name, setName] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [sessions, setSessions] = useState<ChildSession[]>([]);
+
+  useEffect(() => {
+    if (!childId) return;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchChildProfile(childId);
+        setName(data.profile.display_name || '');
+        setPrompt(data.profile.system_message || '');
+        setSessions(data.sessions);
+      } catch (err) {
+        console.error('Failed to load child', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [childId]);
+
+  if (!isAdult) {
+    return <p className="p-4">Access denied.</p>;
+  }
+
+  if (!childId) {
+    return <p className="p-4">Child not found.</p>;
+  }
+
+  const save = async () => {
+    try {
+      await updateChildProfile(childId, { display_name: name, system_message: prompt });
+    } catch (err) {
+      console.error('Update failed', err);
+    }
+  };
+
+  const removeSession = async (id: string) => {
+    const { error } = await invokeWithAuth('deleteSession', { id });
+    if (!error) {
+      setSessions((prev) => prev.filter((s) => s.id !== id));
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-4">
+        <Loader2 className="animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="fixed top-0 w-full bg-white border-b border-gray-100 h-14 flex items-center px-4 z-10">
+        <Button variant="ghost" size="icon" onClick={() => navigate('/profile')}>
+          <ArrowLeft />
+          <span className="sr-only">Back</span>
+        </Button>
+        <h1 className="flex-1 text-center font-medium">Child</h1>
+      </header>
+      <main className="pt-16 p-4 max-w-md mx-auto space-y-4">
+        <EditableField value={name} onChange={setName} onSave={save} />
+        <EditableField
+          value={prompt}
+          onChange={setPrompt}
+          onSave={save}
+          className="text-sm text-muted-foreground"
+          inputClassName="max-w-[250px] border-gray-300"
+          buttonClassName="h-7 w-7 text-gray-500 hover:text-gray-700"
+        />
+        <ul className="space-y-2">
+          {sessions.map((s) => (
+            <li key={s.id} className="flex items-center gap-2">
+              <Link to={`/chat/${s.id}`} className="flex-1 overflow-hidden">
+                <span className="font-bold block truncate">{s.name || 'Chat'}</span>
+                <span className="text-xs text-muted-foreground truncate">
+                  {s.session_summary}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {new Date(s.created_at).toLocaleDateString()}
+                </span>
+              </Link>
+              <button aria-label="Delete" onClick={() => removeSession(s.id)}>
+                <Trash2 size={16} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </div>
+  );
+};
+
+export default ChildView;

--- a/src/utils/childViewApi.ts
+++ b/src/utils/childViewApi.ts
@@ -1,0 +1,31 @@
+import { fetchWithAuth } from '@/lib/fetchWithAuth';
+
+export interface ChildSession {
+  id: string;
+  name: string | null;
+  session_summary: string;
+  created_at: string;
+}
+
+export interface ChildProfileResponse {
+  profile: { id: string; display_name: string | null; system_message: string | null };
+  sessions: ChildSession[];
+}
+
+export async function fetchChildProfile(childId: string): Promise<ChildProfileResponse> {
+  const res = await fetchWithAuth(`/functions/v1/child-view?id=${childId}`);
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || 'Failed');
+  return data;
+}
+
+export async function updateChildProfile(childId: string, updates: { display_name?: string; system_message?: string }) {
+  const res = await fetchWithAuth(`/functions/v1/child-view?id=${childId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updates)
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || 'Failed');
+  return data;
+}

--- a/supabase/functions/child-view/index.ts
+++ b/supabase/functions/child-view/index.ts
@@ -1,0 +1,68 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { corsHeaders } from "../_shared/cors.ts";
+
+function jsonResponse(payload: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const url = Deno.env.get("SUPABASE_URL")!;
+  const anon = Deno.env.get("SUPABASE_ANON_KEY")!;
+
+  const token = req.headers.get("authorization")?.replace("Bearer ", "");
+  if (!token) return jsonResponse({ error: "Unauthorized" }, 401);
+
+  const supabase = createClient(url, anon, {
+    global: { headers: { authorization: `Bearer ${token}` } },
+  });
+
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  if (!id) return jsonResponse({ error: "id required" }, 400);
+
+  if (req.method === "GET") {
+    const { data: profile, error: profErr } = await supabase
+      .from("profiles")
+      .select("id, display_name, system_message")
+      .eq("id", id)
+      .maybeSingle();
+    if (profErr) return jsonResponse({ error: profErr.message }, 500);
+
+    const { data: sessions, error: sessErr } = await supabase
+      .from("chat_sessions")
+      .select("id, name, session_summary, created_at")
+      .eq("user_id", id)
+      .order("created_at", { ascending: false });
+    if (sessErr) return jsonResponse({ error: sessErr.message }, 500);
+
+    return jsonResponse({ profile, sessions });
+  }
+
+  if (req.method === "PATCH") {
+    let body: { display_name?: string; system_message?: string };
+    try { body = await req.json(); } catch { body = {}; }
+    const updates: Record<string, string> = {};
+    if (typeof body.display_name === "string") updates.display_name = body.display_name;
+    if (typeof body.system_message === "string") updates.system_message = body.system_message;
+    if (Object.keys(updates).length === 0) {
+      return jsonResponse({ error: "No fields to update" }, 400);
+    }
+    updates.updated_at = new Date().toISOString();
+    const { error } = await supabase
+      .from("profiles")
+      .update(updates)
+      .eq("id", id);
+    if (error) return jsonResponse({ error: error.message }, 500);
+    return jsonResponse({ success: true });
+  }
+
+  return jsonResponse({ error: "Method not allowed" }, 405);
+});

--- a/supabase/migrations/20250528090000_parent_child_delete.sql
+++ b/supabase/migrations/20250528090000_parent_child_delete.sql
@@ -1,0 +1,34 @@
+-- Allow parents to delete child profiles and sessions
+
+DROP POLICY IF EXISTS "Parents can delete their children profiles" ON public.profiles;
+CREATE POLICY "Parents can delete their children profiles"
+  ON public.profiles FOR DELETE TO authenticated
+  USING (parent_id = auth.uid());
+
+DROP POLICY IF EXISTS "Parents can update their children sessions" ON public.chat_sessions;
+CREATE POLICY "Parents can update their children sessions"
+  ON public.chat_sessions FOR UPDATE TO authenticated
+  USING (
+    user_id IN (SELECT id FROM public.profiles WHERE parent_id = auth.uid())
+  )
+  WITH CHECK (
+    user_id IN (SELECT id FROM public.profiles WHERE parent_id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Parents can delete their children sessions" ON public.chat_sessions;
+CREATE POLICY "Parents can delete their children sessions"
+  ON public.chat_sessions FOR DELETE TO authenticated
+  USING (
+    user_id IN (SELECT id FROM public.profiles WHERE parent_id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Parents can delete their children messages" ON public.chat_messages;
+CREATE POLICY "Parents can delete their children messages"
+  ON public.chat_messages FOR DELETE TO authenticated
+  USING (
+    session_id IN (
+      SELECT id FROM public.chat_sessions WHERE user_id IN (
+        SELECT id FROM public.profiles WHERE parent_id = auth.uid()
+      )
+    )
+  );


### PR DESCRIPTION
### What & Why
- implement `/children/:childId` page so adults can manage a child
- create `child-view` edge function returning a child profile with sessions and allowing profile edits
- add fetchWithAuth helper with tests
- update RLS policies to let parents update/delete child data
- add migration entry and changelog note

### How Tested
```bash
bun run lint
bun run test
```
