### PR TITLE
fix(profile): link child names to view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 - Resolve Netlify 404 when navigating directly to `/login`.
+- Child account names on the adult profile page link to the child view.
 
 ## [1.4.0] - 2025-05-26
 ### Added

--- a/src/components/profile/ChildAccountsSection.tsx
+++ b/src/components/profile/ChildAccountsSection.tsx
@@ -99,7 +99,12 @@ const ChildAccountsSection: React.FC = () => {
         )}
         {children.map((child) => (
           <div key={child.id} className="space-y-1">
-            <p className="text-sm font-medium">{child.display_name || child.id}</p>
+            <Link
+              to={`/children/${child.id}`}
+              className="text-sm font-medium hover:underline"
+            >
+              {child.display_name || child.id}
+            </Link>
             {isAdult ? (
               <EditableField
                 value={child.system_message || ''}


### PR DESCRIPTION
### What & Why
- connect child account names on the adult profile page to the child view route

### How Tested
```bash
bun run lint && bun run test
```

### Codex Guardrail Checklist
- [x] I ran `bun run test` and all suites pass.
- [x] No env var or public API contract was renamed; if yes, I updated docs & affected code.
- [ ] For any DB change, I added a Supabase migration **and** RLS policy.
- [ ] I verified the migration runs on Postgres 14 (`supabase start`).
- [ ] I reproduced the original bug with a failing test and the test now passes.
- [ ] I manually tested streaming in the Netlify preview (desktop + mobile).
- [x] I confirmed UI affordances match existing hover/tap behaviour.
- [ ] I updated `docs/codex_guardrails.md` if I introduced new patterns or learned lessons.