### PR TITLE
fix chat naming regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Fixed
 - Resolve Netlify 404 when navigating directly to `/login`.
 - Child account names on the adult profile page link to the child view.
+- Chat sessions update to GPT-generated titles again
 
 ## [1.4.0] - 2025-05-26
 ### Added

--- a/src/hooks/useChatNameGenerator.ts
+++ b/src/hooks/useChatNameGenerator.ts
@@ -31,7 +31,7 @@ export const useChatNameGenerator = (
       count !== lastGeneratedCountRef.current
     ) {
       lastGeneratedCountRef.current = count;
-      generateChatName(activeChatId)
+      generateChatName(activeChatId, messages)
         .then(({ title, sessionSummary }) => {
           updateChatName(activeChatId, title);
           stashSummary(activeChatId, sessionSummary);

--- a/src/utils/chatNameGenerator.ts
+++ b/src/utils/chatNameGenerator.ts
@@ -1,12 +1,21 @@
 
 import { invokeWithAuth } from '@/lib/invokeWithAuth';
 
+import { Message } from '@/types/chat';
+
 export const generateChatName = async (
   sessionId: string,
+  messages: Message[],
 ): Promise<{ title: string; sessionSummary: string }> => {
   try {
+    const formatted = messages.map(m => ({
+      role: m.isUser ? 'user' : 'assistant',
+      content: m.content,
+    }));
+
     const { data, error } = await invokeWithAuth('generate-chat-name', {
       session_id: sessionId,
+      messages: formatted,
     });
 
     if (error) {


### PR DESCRIPTION
### What & Why
- restore GPT session titles by sending chat history to `generate-chat-name`
- update CHANGELOG

### How Tested
```bash
bun run lint && bun run test
```
