### PR TITLE
Fix: clarify auto session title trigger

### DIFF
--- a/src/hooks/useChatNameGenerator.ts
+++ b/src/hooks/useChatNameGenerator.ts
@@ -30,6 +30,7 @@ export const useChatNameGenerator = (
     const count = assistantMessages.length;
 
     if (
+      // Run after the third assistant reply
       count >= 3 &&
       count % 3 === 0 &&
       !isWaitingForResponse &&


### PR DESCRIPTION
### What & Why
- ensure session name generation triggers after the 3rd assistant reply by documenting the check

### How Tested
```bash
bun run lint && bun run test
```
