### PR TITLE
Update guardrails and session-name PRD

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -47,6 +47,29 @@ CI will enforce; run locally before committing.
 Feature Logging
 For every PR tagged `feat:` you must add an entry to CHANGELOG.md under `Unreleased`.
 
+### Edge-Function Tests
+        •       Path-filter CI so these run only when files under `supabase/functions/` change or when manually dispatched.
+        •       Keep the default PR workflow under 4 minutes.
+
+### Skipped Tests Lint
+        •       eslint-plugin-vitest rejects `describe.skip` or `test.only` in committed code.
+
+### Cost Guardrail
+        •       Default model is `gpt-4.1-nano`.
+        •       To upgrade, flip `featureFlags.metadataModel` and document cost + latency comparison.
+        •       Obtain @dudgeon approval before merging.
+
+### Online RLS Migration Pattern
+        •       Add the new policy in a first release.
+        •       Back-fill data with both policies active.
+        •       Drop the old policy in a later release.
+
+### Guard-Clause Integration Test
+        •       Assert the title/summary generator fires once per session.
+
+### Multi-Concern PR Rule
+        •       If a change spans edge function, client, and CI updates, create separate PRs.
+
 
 ⸻
 

--- a/docs/prds/automatic session name and summary generation.md
+++ b/docs/prds/automatic session name and summary generation.md
@@ -76,10 +76,19 @@ A concise **title** and one-sentence **summary** make it easy for parents and ki
 | RLS blocks updates       | CI test validates service-role write succeeds. |
 
 ## 8. Release Plan
-1. Develop behind feature flag `metadata_v2`.  
-2. QA with synthetic 50-message chat.  
-3. Gradual rollout 10 % → 100 %.  
+1. Develop behind feature flag `metadata_v2`.
+2. QA with synthetic 50-message chat.
+3. Gradual rollout 10 % → 100 %.
 4. Monitor cost and error logs for 7 days.
+
+## 9. Implementation Notes & Guardrails
+* **Default model:** `gpt-4.1-nano`; upgrades toggled via `featureFlags.metadataModel`.
+* **Guard clause:** `if (!chatName || !chatSummary)` prevents duplicate generator calls.
+* **Integration test:** verify the name/summary generator executes once per session with coverage.
+* **Model change gate:** document cost & latency benchmarks and secure @dudgeon approval before merging.
+* **RLS online migration:** add new policy, back-fill rows, drop old policy in a later release.
+* **Edge-function CI:** path filter so edge-function tests run only on `supabase/functions/**` changes.
+* **Acceptance:** zero user-visible downtime and no duplicate DB writes.
 
 ---
 


### PR DESCRIPTION
## Summary
- extend `AGENTS.md` with edge-function testing, cost guardrails, RLS migration pattern and other new rules
- update session name PRD with guard clause details and cost benchmarks

## Testing
- `bun run lint`
- `bun run test`
